### PR TITLE
Harden checkphrase scheme: Argon2id, address normalization, configurable word count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 target
 .idea
+.venv
+__pycache__
 /dart/.dart_tool
 node_modules
 dist

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,10 +24,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
-name = "atomic-waker"
-version = "1.1.2"
+name = "argon2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
 
 [[package]]
 name = "autocfg"
@@ -51,31 +42,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "backtrace"
-version = "0.3.74"
+name = "base64ct"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
+ "digest",
 ]
-
-[[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "bitflags"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "block-buffer"
@@ -93,25 +72,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
-name = "bytes"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
-
-[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
-
-[[package]]
-name = "cc"
-version = "1.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
-dependencies = [
- "shlex",
-]
 
 [[package]]
 name = "cfg-if"
@@ -170,22 +134,6 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -285,132 +233,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "errno"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
-name = "form_urlencoded"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
-
-[[package]]
-name = "futures-sink"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
-
-[[package]]
-name = "futures-task"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-util"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
-dependencies = [
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "pin-utils",
- "slab",
-]
 
 [[package]]
 name = "generic-array"
@@ -420,54 +246,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
-]
-
-[[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
-name = "h2"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -481,298 +259,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
-
-[[package]]
 name = "hermit-abi"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
-
-[[package]]
-name = "http"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
-dependencies = [
- "bytes",
- "http",
-]
-
-[[package]]
-name = "http-body-util"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
-dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "pin-project-lite",
-]
-
-[[package]]
-name = "httparse"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "hyper"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "httparse",
- "itoa",
- "pin-project-lite",
- "smallvec",
- "tokio",
- "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.27.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
-dependencies = [
- "futures-util",
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-util"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "icu_collections"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
-name = "icu_normalizer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
-
-[[package]]
-name = "icu_properties"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_locid_transform",
- "icu_properties_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
-
-[[package]]
-name = "icu_provider"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
- "writeable",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "idna"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
-dependencies = [
- "equivalent",
- "hashbrown",
-]
-
-[[package]]
-name = "ipnet"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "is-terminal"
@@ -782,7 +272,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -817,18 +307,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
-
-[[package]]
-name = "litemap"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
-
-[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,64 +319,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
-dependencies = [
- "adler2",
-]
-
-[[package]]
-name = "mio"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
-dependencies = [
- "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -914,82 +340,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "openssl"
-version = "0.10.71"
+name = "password-hash"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
+ "base64ct",
+ "rand_core",
+ "subtle",
 ]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.106"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest",
- "hmac",
-]
-
-[[package]]
-name = "percent-encoding"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plotters"
@@ -1032,11 +391,8 @@ dependencies = [
 name = "qp-human-checkphrase"
 version = "2.2.1"
 dependencies = [
+ "argon2",
  "criterion",
- "hex",
- "hmac",
- "pbkdf2",
- "reqwest",
  "serde",
  "serde_json",
  "sha2",
@@ -1052,10 +408,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "r-efi"
-version = "5.2.0"
+name = "rand_core"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rayon"
@@ -1107,123 +463,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "reqwest"
-version = "0.12.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
-dependencies = [
- "base64",
- "bytes",
- "encoding_rs",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-tls",
- "hyper-util",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "system-configuration",
- "tokio",
- "tokio-native-tls",
- "tower",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "windows-registry",
-]
-
-[[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.15",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
-name = "rustix"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
-dependencies = [
- "once_cell",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa4eeac2588ffff23e9d7a7e9b3f971c5fb5b7ebc9452745e0c232c64f83b2f"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,38 +481,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "schannel"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -1309,18 +516,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1330,43 +525,6 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "slab"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "smallvec"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
-
-[[package]]
-name = "socket2"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "subtle"
@@ -1386,70 +544,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sync_wrapper"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
-dependencies = [
- "fastrand",
- "getrandom 0.3.2",
- "once_cell",
- "rustix",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "tinystr"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
-dependencies = [
- "displaydoc",
- "zerovec",
-]
-
-[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1458,106 +552,6 @@ dependencies = [
  "serde",
  "serde_json",
 ]
-
-[[package]]
-name = "tokio"
-version = "1.44.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
-dependencies = [
- "backtrace",
- "bytes",
- "libc",
- "mio",
- "pin-project-lite",
- "socket2",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
-dependencies = [
- "rustls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tower"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project-lite",
- "sync_wrapper",
- "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
-
-[[package]]
-name = "tower-service"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
-
-[[package]]
-name = "tracing"
-version = "0.1.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
-dependencies = [
- "pin-project-lite",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "try-lock"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -1570,41 +564,6 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "url"
-version = "2.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
-]
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1620,30 +579,6 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
-]
-
-[[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
-]
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
-dependencies = [
- "wit-bindgen-rt",
 ]
 
 [[package]]
@@ -1670,19 +605,6 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
-dependencies = [
- "cfg-if",
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -1733,51 +655,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
-
-[[package]]
-name = "windows-registry"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
-dependencies = [
- "windows-result",
- "windows-strings",
- "windows-targets 0.53.0",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1786,7 +664,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1795,30 +673,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
-dependencies = [
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -1828,22 +690,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1852,22 +702,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1876,22 +714,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1900,113 +726,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
-
-[[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
-name = "writeable"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
-name = "yoke"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
-dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zeroize"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
-
-[[package]]
-name = "zerovec"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Quantus Network"]
 categories = ["cryptography", "encoding"]
-description = "Generate human-readable checksums from cryptocurrency addresses using BIP-39 words and PBKDF2 to prevent address poisoning attacks"
+description = "Generate human-readable checksums from cryptocurrency addresses using BIP-39 words and Argon2id to prevent address poisoning attacks"
 edition = "2021"
 keywords = [
 	"address",
@@ -17,14 +17,11 @@ repository = "https://github.com/quantus/qp-human-checkphrase"
 version = "2.2.1"
 
 [dependencies]
-hex = "0.4.3"
-hmac = "0.12"
-pbkdf2 = "0.12"
-reqwest = { version = "0.12.12", features = ["blocking"] }
-sha2 = "0.10"
+argon2 = "0.5"
 
 [dev-dependencies]
 criterion = "0.5"
+sha2 = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,50 @@
 # human-checkphrase
 
-A tool to generate human-readable checksums from cryptocurrency addresses using a curated positive wordlist and PBKDF2. 
+A tool to generate human-readable checksums from cryptocurrency addresses using a curated positive wordlist and Argon2id.
 Designed to make address verification easier and prevent address poisoning attacks—where attackers craft lookalike addresses to trick users, this tool can be used with any existing blockchain address. Users viewing an address can also be presented with a unique, memorable phrase.
 
 ## Examples
 
 | Address | Chain | Checkphrase |
 |---------|-------|-------------|
-| `1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa` | Bitcoin | Age-Awake-Secret-Blossom-Hedgehog |
-| `1A1zP1eP5QGefi2DMPTfTL5SLmv7DixfNa` | Bitcoin (poisoned) | Innocent-Fitness-Joyful-Brown-Surge |
-| `0x742d35Cc6634C0532925a3b844Bc9e7595f5bE21` | Ethereum | Donkey-Crucial-Beach-Offer-Expire |
-| `5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY` | Polkadot | Merge-Boss-Syrup-Inestimable-Toss |
-| `cosmos1hsk6jryyqjfhp5dhc55tc9jtckygx0eph6dd02` | Cosmos | Find-Frog-Basic-Reopen-Another |
-| `bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq` | Bitcoin (bech32) | View-Start-Satisfy-Immense-Clown |
-| `qzk7h3xH4Fmv2RqKpN8sT5jW9cY6gB1dL3mX0vQwEaUoZrJtS` | Quantus | Unveil-Butter-Always-Since-Schnorr |
-| `qzkABCDEF123456789abcdefGHIJKLMNOPQRSTUVWXYZ000001` | Quantus | Patch-Invite-Split-Surface-Dial |
-| `qzkXyZ987654321FeDcBaAbCdEfGhIjKlMnOpQrStUvWxYz99` | Quantus | Important-Extend-Barely-Close-Text |
+| `1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa` | Bitcoin | Cake-Stuff-Nerve-Job-Subway |
+| `1A1zP1eP5QGefi2DMPTfTL5SLmv7DixfNa` | Bitcoin (poisoned) | Polar-Pet-Music-Already-Act |
+| `0x742d35Cc6634C0532925a3b844Bc9e7595f5bE21` | Ethereum | Meaningful-Curve-Raccoon-Festival-Scan |
+| `5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY` | Polkadot | Cricket-Rare-Significant-Above-Grateful |
+| `cosmos1hsk6jryyqjfhp5dhc55tc9jtckygx0eph6dd02` | Cosmos | Dash-Health-Unfazed-Section-Ivory |
+| `bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq` | Bitcoin (bech32) | History-Unbound-Fix-Add-Alter |
+| `qzk7h3xH4Fmv2RqKpN8sT5jW9cY6gB1dL3mX0vQwEaUoZrJtS` | Quantus | Mimic-Advance-Satisfy-Unusual-Tell |
+| `qzkABCDEF123456789abcdefGHIJKLMNOPQRSTUVWXYZ000001` | Quantus | Gap-Puppy-Cipher-Topic-Food |
+| `qzkXyZ987654321FeDcBaAbCdEfGhIjKlMnOpQrStUvWxYz99` | Quantus | Cycle-Boost-Sustain-Exuberance-Course |
 
 Notice how the first two Bitcoin addresses differ by only one character (`v` vs `x`) but produce completely different checkphrases—this is exactly what helps prevent address poisoning attacks.
+
+## The scheme (v2)
+
+1. **Normalize the address.** Surrounding whitespace is stripped. `0x`-prefixed
+   hexadecimal addresses are lowercased so that EIP-55 checksum casing does not
+   change the checkphrase (two wallets displaying the same Ethereum address with
+   different casing must show the same phrase). All other encodings (base58,
+   bech32, SS58, ...) are case-sensitive and passed through unchanged; callers
+   must supply them in canonical form (e.g. lowercase bech32).
+2. **Derive key bytes with Argon2id** (RFC 9106): 64 MiB memory, 3 passes,
+   parallelism 1, version 0x13. The salt is the scheme version string
+   `human-checkphrase-v2`, optionally extended with a caller-supplied
+   domain-separation context: `human-checkphrase-v2|<context>` (e.g. a chain id
+   such as `eip155:1`). Two wallets must use the same context—or none—to see
+   the same phrase for an address. Any future change to the KDF, its
+   parameters, or the wordlist bumps the version string.
+3. **Map to words.** The output (`ceil(wordCount * 11 / 8)` bytes) is read as a
+   big-endian integer, the low `(8 * len) % 11` bits are dropped, and the
+   remaining bits are split into `wordCount` 11-bit indices into the
+   2048-word list.
+
+The word count is configurable from 3 to 11 words and defaults to **5 words
+(55 bits)**. Five words are appropriate for the intended use: *verification*,
+i.e. comparing the phrase of an address you already have against the phrase
+you expect. If you ever use phrases as identifiers (e.g. looking up an address
+by phrase), you need collision resistance against multi-target attacks—use 8+
+words (88+ bits), and see the security analysis below.
 
 ## Wordlist
 
@@ -45,7 +72,7 @@ The canonical wordlist is `final_wordlist.txt` in the repo root. Copies exist in
 python3 scripts/sync_wordlists.py
 ```
 
-To regenerate test vectors (1171 vectors covering all 2048 words):
+To regenerate test vectors (requires `pip install argon2-cffi`):
 
 ```bash
 python3 scripts/generate_test_vectors.py
@@ -56,7 +83,7 @@ python3 scripts/generate_test_vectors.py
 - **Rust**: A library crate at the root for fast, reusable checksum generation
 - **JavaScript/TypeScript**: NPM package in `js/`
 - **Dart**: Pub package in `dart/`
-- **Python**: Prototype scripts in `scripts/` for experimentation and reference
+- **Python**: Reference implementation in `scripts/checkphrase.py`
 
 ### Running tests
 
@@ -69,30 +96,65 @@ Or run individually:
 - JavaScript: `cd js && npm test`
 - Dart: `cd dart && dart test`
 
-Tests validate against 1171 shared test vectors in `test-vectors/checksums.json` to ensure all implementations produce identical results.
+Tests validate against shared test vectors in `test-vectors/checksums.json`—including
+normalization, non-default word counts, and domain-separation contexts—to ensure all
+implementations produce identical results.
 
 ## Security Analysis
 
-Each of the words has 2048 (2^11) choices so if we choose 5 words, we have a total set of 2^55 ~ 36 quadrillion possible combinations. 
-The parameters for PBKDF2 are chosen to enable fast UI generation while still requiring an attacker to do ~50000x more work to generate rainbow tables. 
-Run `cargo bench` to see the comparison of doing just SHA256 to generate the checksum vs using PBKDF2.
+Each word carries 11 bits (2048 choices), so the default 5-word phrase has
+2^55 ≈ 36 quadrillion possible values.
 
-On a typical MacBook, a single SHA256 hash takes ~262ns, so the time to generate an entire rainbow table (single-threaded CPU) would be:
-`2^55 * 262ns ≈ 300 years`
+### Threat model: verification vs. identification
 
-With PBKDF2 (40,000 iterations), each checksum takes ~14ms, so a rainbow table would take:
-`2^55 * 14ms ≈ 16 million years`
+The checkphrase is a *verification* aid: the user already holds an address and
+compares its phrase against the one they expect. An attacker (e.g. address
+poisoning) must therefore generate an address whose phrase matches one
+*specific* 55-bit target—a second-preimage attack requiring ~2^55 KDF
+evaluations in expectation.
 
-A high-end GPU can compute SHA256 ~10x faster than a CPU, reducing each PBKDF2 call to ~1.4ms. Even then:
-`2^55 * 1.4ms ≈ 1.6 million years` per GPU
+The phrase is **not** an identifier. If phrases are used to *look up*
+addresses, an attacker profits from colliding with *any* of N valuable
+addresses at once, which cuts the work to 2^55 / N; with a million targets
+that is only ~2^35 evaluations. Reverse lookup also turns a collision from a
+visible mismatch into a coin-flip for the user. If you need lookup, use 8+
+words and a registry that enforces phrase uniqueness.
 
-With a cluster of 1,000 GPUs working in parallel: ~1,600 years.
+### Why Argon2id instead of PBKDF2
 
+Version 1 of this scheme used PBKDF2-HMAC-SHA256 (40,000 iterations). PBKDF2
+imposes only compute cost, and SHA-256 is the most hardware-accelerated
+function in existence: a single consumer GPU computes ~20 GH/s of SHA-256,
+i.e. ~250,000 PBKDF2-40k guesses per second—about 3,500x faster than the
+~14 ms a defender pays per phrase. Bitcoin-mining ASICs widen that gap by
+several more orders of magnitude.
 
-This of course does not include the time it takes to generate a private key, derive a public key and address from it, which can add another 10ms for dilithium keys (nearly doubling) or 10 us for elliptic curves. 
-It also does not take into account if the attacker wants a similar looking address in addition to the same checksum, which multiplies the required effort by many orders of magnitude.
+Argon2id is *memory-hard*: every evaluation must fill and randomly access
+64 MiB. Attacker throughput is then bounded by memory size and bandwidth, not
+core count—a 24 GB GPU fits only ~375 concurrent instances and its bandwidth
+supports on the order of 10^3 guesses/second, within ~100x of a defender's
+laptop core instead of the ~10^5-10^8x gap for SHA-256-based schemes.
 
-Using 4 words still provides a fair bit of security, `2**44 * 14 / 1000 / 60 / 60 / 24 / 365` or ~7800 years on a single CPU.
+### Attack cost estimates (Argon2id, 64 MiB, t=3)
+
+A defender pays ~50-150 ms per phrase on typical hardware. Assuming an
+attacker manages ~2,000 guesses/second per high-end GPU:
+
+| Attack | Work | Time on 1 GPU | Time on 1,000 GPUs |
+|--------|------|---------------|--------------------|
+| Targeted collision, 5 words | 2^55 | ~570,000 years | ~570 years |
+| Targeted collision, 4 words | 2^44 | ~280 years | ~100 days |
+| Multi-target (10^6 lookup targets), 5 words | ~2^35 | ~200 days | ~5 hours |
+| Multi-target (10^6 lookup targets), 8 words | ~2^68 | ~4.7 billion years | ~4.7 million years |
+
+These estimates exclude key generation: each candidate address needs a real
+keypair, which adds ~10 ms for Dilithium (Quantus) or ~10 µs for elliptic
+curves per attempt. They also exclude the extra effort if the attacker wants
+the colliding address to *look* similar to the target, which multiplies the
+work by many orders of magnitude.
+
+Run `cargo bench` to compare a bare SHA-256 checksum against Argon2id on your
+hardware.
 
 ## Installation
 
@@ -101,7 +163,19 @@ Using 4 words still provides a fair bit of security, `2**44 * 14 / 1000 / 60 / 6
 Add to your `Cargo.toml`:
 ```toml
 [dependencies]
-human_readable_checksum = { git = "https://github.com/Quantus-Network/human-checkphrase" }
+qp-human-checkphrase = { git = "https://github.com/Quantus-Network/human-checkphrase" }
+```
+
+```rust
+use qp_human_checkphrase::{load_word_list, address_to_checksum, address_to_checksum_with_options};
+
+let word_list = load_word_list()?;
+let phrase = address_to_checksum("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", &word_list);
+println!("{}", phrase.join("-")); // Cake-Stuff-Nerve-Job-Subway
+
+// 8 words, domain-separated per chain
+let phrase = address_to_checksum_with_options(
+    "0x742d35Cc6634C0532925a3b844Bc9e7595f5bE21", &word_list, 8, Some("eip155:1"))?;
 ```
 
 ### JavaScript/TypeScript
@@ -114,8 +188,11 @@ npm install human-readable-checksum
 import { loadWordList, addressToChecksum } from "human-readable-checksum";
 
 const wordList = loadWordList();
-const checksum = addressToChecksum("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", wordList);
-console.log(checksum.join("-")); // Age-Awake-Secret-Blossom-Hedgehog
+const checksum = await addressToChecksum("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", wordList);
+console.log(checksum.join("-")); // Cake-Stuff-Nerve-Job-Subway
+
+// 8 words, domain-separated per chain
+const long = await addressToChecksum(address, wordList, { wordCount: 8, context: "eip155:1" });
 ```
 
 ### Dart
@@ -127,4 +204,12 @@ dependencies:
     git:
       url: https://github.com/Quantus-Network/human-checkphrase
       path: dart
+```
+
+```dart
+final checksum = HumanChecksum(wordList);
+final words = checksum.addressToChecksum('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa');
+
+// 8 words, domain-separated per chain
+final long = checksum.addressToChecksum(address, wordCount: 8, context: 'eip155:1');
 ```

--- a/benches/checksum_bench.rs
+++ b/benches/checksum_bench.rs
@@ -7,8 +7,8 @@ fn bench_checksum(c: &mut Criterion) {
 	let word_list = load_word_list().expect("Failed to load word list");
 	let address = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa";
 
-	// Benchmark PBKDF2 (current method)
-	c.bench_function("pbkdf2_40k", |b| {
+	// Benchmark Argon2id (current method)
+	c.bench_function("argon2id_64mib_t3", |b| {
 		b.iter(|| black_box(address_to_checksum(black_box(address), &word_list)))
 	});
 

--- a/dart/README.md
+++ b/dart/README.md
@@ -1,6 +1,6 @@
 # human_checksum
 
-A Dart implementation of human-readable checksums for cryptocurrency addresses using the BIP-39 word list and PBKDF2.
+A Dart implementation of human-readable checkphrases for cryptocurrency addresses using a curated 2048-word list and Argon2id.
 
 ## Usage
 
@@ -8,16 +8,23 @@ A Dart implementation of human-readable checksums for cryptocurrency addresses u
 import 'package:human_checksum/human_checksum.dart';
 
 void main() {
-  // Load the BIP-39 word list (2048 words)
+  // Load the word list (2048 words)
   final wordList = File('path/to/wordlist.txt').readAsLinesSync();
-  
+
   final checksum = HumanChecksum(wordList);
   final address = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
-  
+
   final words = checksum.addressToChecksum(address);
-  print(words.join('-')); // e.g. "museum-saddle-orphan-ribbon-peace"
+  print(words.join('-')); // "cake-stuff-nerve-job-subway"
+
+  // Optional: longer phrase, domain-separated per chain
+  final long = checksum.addressToChecksum(address, wordCount: 8, context: 'bitcoin');
 }
 ```
+
+Addresses are normalized before hashing: surrounding whitespace is stripped and
+`0x`-prefixed hex addresses are lowercased (so EIP-55 casing does not change the
+phrase). Other encodings must be passed in canonical form.
 
 ## Installation
 
@@ -33,4 +40,4 @@ dependencies:
 
 ## License
 
-MIT License - see LICENSE file 
+MIT License - see LICENSE file

--- a/dart/lib/src/human_checksum_base.dart
+++ b/dart/lib/src/human_checksum_base.dart
@@ -1,30 +1,79 @@
 import 'dart:convert';
-import 'dart:typed_data';
-import 'package:crypto/crypto.dart';
 import 'package:pointycastle/export.dart';
 
 class HumanChecksum {
-  static const int wordCount = 2048;
-  static const String salt = 'human-readable-checksum';
-  static const int iterations = 40000;
-  static const int checksumLen = 5;
-  static const int keyBytecount = (checksumLen * 11 + 7) ~/ 8;
+  static const int wordListSize = 2048;
+
+  /// Scheme version string, also used as the Argon2 salt (optionally extended
+  /// with a domain-separation context: "human-checkphrase-v2|<context>").
+  static const String version = 'human-checkphrase-v2';
+
+  // Argon2id parameters (RFC 9106), must match all other implementations.
+  static const int memoryKiB = 64 * 1024;
+  static const int timeCost = 3;
+  static const int parallelism = 1;
+
+  static const int defaultWordCount = 5;
+
+  /// Argon2 output must be at least 4 bytes; 3 words -> 5 key bytes.
+  static const int minWordCount = 3;
+
+  /// 11 words = 121 bits; keeps parity with the Rust implementation's u128.
+  static const int maxWordCount = 11;
 
   final List<String> wordList;
 
   HumanChecksum(this.wordList) {
-    if (wordList.length != wordCount) {
-      throw ArgumentError('Word list must contain exactly $wordCount words');
+    if (wordList.length != wordListSize) {
+      throw ArgumentError('Word list must contain exactly $wordListSize words');
     }
   }
 
-  List<String> addressToChecksum(String address) {
-    // PBKDF2-HMAC-SHA256
-    final params = Pbkdf2Parameters(utf8.encode(salt), iterations, keyBytecount);
-    final pbkdf2 = PBKDF2KeyDerivator(HMac(SHA256Digest(), 64));
-    pbkdf2.init(params);
+  /// Canonicalize an address string before hashing.
+  ///
+  /// Surrounding whitespace is stripped. 0x-prefixed hexadecimal addresses
+  /// are lowercased so that EIP-55 checksum casing does not change the
+  /// checkphrase. All other encodings (base58, bech32, SS58, ...) are
+  /// case-sensitive and are passed through unchanged; callers must supply
+  /// them in canonical form.
+  static String normalizeAddress(String address) {
+    final trimmed = address.trim();
+    if (RegExp(r'^0[xX][0-9a-fA-F]+$').hasMatch(trimmed)) {
+      return trimmed.toLowerCase();
+    }
+    return trimmed;
+  }
 
-    final key = pbkdf2.process(utf8.encode(address));
+  /// Generate a checkphrase of [wordCount] words, optionally domain-separated
+  /// by [context] (e.g. a chain id such as "eip155:1"). Two wallets must use
+  /// the same context to see the same phrase for an address.
+  List<String> addressToChecksum(
+    String address, {
+    int wordCount = defaultWordCount,
+    String? context,
+  }) {
+    if (wordCount < minWordCount || wordCount > maxWordCount) {
+      throw ArgumentError(
+          'wordCount must be between $minWordCount and $maxWordCount, got $wordCount');
+    }
+
+    final keyByteCount = (wordCount * 11 + 7) ~/ 8;
+    final salt =
+        (context == null || context.isEmpty) ? version : '$version|$context';
+
+    // Argon2id: memory-hard KDF so that GPU/ASIC farms cannot grind
+    // checkphrase collisions much faster than commodity hardware.
+    final params = Argon2Parameters(
+      Argon2Parameters.ARGON2_id,
+      utf8.encode(salt),
+      version: Argon2Parameters.ARGON2_VERSION_13,
+      iterations: timeCost,
+      memory: memoryKiB,
+      lanes: parallelism,
+      desiredKeyLength: keyByteCount,
+    );
+    final generator = Argon2BytesGenerator()..init(params);
+    final key = generator.process(utf8.encode(normalizeAddress(address)));
 
     // Convert key bytes to a big integer
     var keyInt = BigInt.zero;
@@ -32,13 +81,13 @@ class HumanChecksum {
       keyInt = (keyInt << 8) | BigInt.from(byte);
     }
 
-    // Take only the first checksumLen * 11 bits
-    keyInt = keyInt >> ((8 * keyBytecount) % 11);
+    // Take only the first wordCount * 11 bits
+    keyInt = keyInt >> ((8 * keyByteCount) % 11);
 
     // Split into 11-bit indices
     final indices = <int>[];
-    for (var i = 0; i < checksumLen; i++) {
-      final shift = (checksumLen - 1 - i) * 11;
+    for (var i = 0; i < wordCount; i++) {
+      final shift = (wordCount - 1 - i) * 11;
       final index = ((keyInt >> shift) & BigInt.from(0x7FF)).toInt();
       indices.add(index);
     }

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,5 +1,5 @@
 name: human_checksum
-description: A tool to generate human-readable checksums from cryptocurrency addresses using the BIP-39 word list and PBKDF2
+description: A tool to generate human-readable checksums from cryptocurrency addresses using the BIP-39 word list and Argon2id
 version: 0.1.0
 homepage: https://github.com/Resonance-Network/human-checksum
 

--- a/dart/test/human_checksum_test.dart
+++ b/dart/test/human_checksum_test.dart
@@ -7,11 +7,15 @@ class TestCase {
   final String address;
   final String description;
   final List<String> expected;
+  final int? wordCount;
+  final String? context;
 
   TestCase({
     required this.address,
     required this.description,
     required this.expected,
+    this.wordCount,
+    this.context,
   });
 
   factory TestCase.fromJson(Map<String, dynamic> json) {
@@ -19,6 +23,8 @@ class TestCase {
       address: json['address'] as String,
       description: json['description'] as String,
       expected: (json['expected'] as List).cast<String>(),
+      wordCount: json['wordCount'] as int?,
+      context: json['context'] as String?,
     );
   }
 }
@@ -76,7 +82,11 @@ void main() {
     var failed = 0;
 
     for (final testCase in testVectors.testCases) {
-      final checksum = humanChecksum.addressToChecksum(testCase.address);
+      final checksum = humanChecksum.addressToChecksum(
+        testCase.address,
+        wordCount: testCase.wordCount ?? HumanChecksum.defaultWordCount,
+        context: testCase.context,
+      );
 
       if (checksum.join(',') == testCase.expected.join(',')) {
         passed++;
@@ -91,7 +101,7 @@ void main() {
 
     print('\nResults: $passed passed, $failed failed');
     expect(failed, equals(0));
-  });
+  }, timeout: Timeout(Duration(minutes: 15)));
 
   test('generates consistent checksums', () {
     final address = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
@@ -106,5 +116,39 @@ void main() {
     final checksum1 = humanChecksum.addressToChecksum(address1);
     final checksum2 = humanChecksum.addressToChecksum(address2);
     expect(checksum1, isNot(equals(checksum2)));
+  });
+
+  test('normalizes hex addresses and whitespace but not base58', () {
+    expect(
+      HumanChecksum.normalizeAddress(
+          ' 0x742d35Cc6634C0532925a3b844Bc9e7595f5bE21\n'),
+      equals('0x742d35cc6634c0532925a3b844bc9e7595f5be21'),
+    );
+    expect(
+      HumanChecksum.normalizeAddress(
+          '0X742D35CC6634C0532925A3B844BC9E7595F5BE21'),
+      equals('0x742d35cc6634c0532925a3b844bc9e7595f5be21'),
+    );
+    expect(
+      HumanChecksum.normalizeAddress('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'),
+      equals('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'),
+    );
+    expect(HumanChecksum.normalizeAddress('0xNotHexZZZ'), equals('0xNotHexZZZ'));
+  });
+
+  test('rejects invalid word counts', () {
+    final address = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
+    expect(() => humanChecksum.addressToChecksum(address, wordCount: 2),
+        throwsArgumentError);
+    expect(() => humanChecksum.addressToChecksum(address, wordCount: 12),
+        throwsArgumentError);
+  });
+
+  test('domain-separates phrases by context', () {
+    final address = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
+    final plain = humanChecksum.addressToChecksum(address);
+    final withContext =
+        humanChecksum.addressToChecksum(address, context: 'bitcoin');
+    expect(withContext, isNot(equals(plain)));
   });
 }

--- a/js/README.md
+++ b/js/README.md
@@ -1,22 +1,31 @@
 # human_checksum
 
-A Javascript implementation of human-readable checksums for cryptocurrency addresses using the BIP-39 word list and PBKDF2.
+A JavaScript implementation of human-readable checkphrases for cryptocurrency addresses using a curated 2048-word list and Argon2id.
 
 ## Usage
 
 ```ts
-import { addressToChecksum, loadBip39List } from "human-readable-checksum";
+import { addressToChecksum, loadWordList } from "human-readable-checksum";
 
 const main = async () => {
-  // Load the BIP-39 word list (2048 words)
-  const wordList = await loadBip39List();
+  // Load the word list (2048 words)
+  const wordList = loadWordList();
   const address = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
 
-  const checksum = addressToChecksum(address, wordList);
+  const checksum = await addressToChecksum(address, wordList);
+  console.log(checksum.join('-')); // "cake-stuff-nerve-job-subway"
 
-  console.log(checksum.join('-')); // e.g. "museum-saddle-orphan-ribbon-peace"
+  // Optional: longer phrase, domain-separated per chain
+  const long = await addressToChecksum(address, wordList, {
+    wordCount: 8,
+    context: 'bitcoin',
+  });
 }
 ```
+
+Addresses are normalized before hashing: surrounding whitespace is stripped and
+`0x`-prefixed hex addresses are lowercased (so EIP-55 casing does not change the
+phrase). Other encodings must be passed in canonical form.
 
 ## Installation
 

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -9,11 +9,10 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "pbkdf2": "^3.1.3"
+        "hash-wasm": "^4.12.0"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
-        "@types/pbkdf2": "^3.1.2",
         "jest": "^30.0.2",
         "ts-jest": "^29.4.0",
         "typescript": "^5.8.3"
@@ -64,7 +63,6 @@
       "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1162,16 +1160,6 @@
         "undici-types": "~7.8.0"
       }
     },
-    "node_modules/@types/pbkdf2": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.2.tgz",
-      "integrity": "sha512-uRwJqmiXmh9++aSu1VNEn3iIxWOhd8AHXNSdlaLfdAAdSTY9jYVeGWnzejM3dvrkbqE3/hyQkQQ29IFATEGlew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -1548,21 +1536,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/available-typed-arrays": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "possible-typed-array-names": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/babel-jest": {
       "version": "30.0.2",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.0.2.tgz",
@@ -1711,7 +1684,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -1754,53 +1726,6 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/call-bound": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -1884,19 +1809,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/cipher-base": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
-      "integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "safe-buffer": "^5.2.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/cjs-module-lexer": {
@@ -2036,32 +1948,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/create-hash": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
-      "integrity": "sha512-snRpch/kwQhcdlnZKYanNF1m0RDlrCdSKQaH87w1FCFPVPNCQ/Il9QJKAX2jVBZddRdaHBMC+zXa9Gw9tmkNUA==",
-      "license": "MIT",
-      "dependencies": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "sha.js": "^2.4.0"
-      }
-    },
-    "node_modules/create-hmac": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-      "license": "MIT",
-      "dependencies": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2120,23 +2006,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -2145,20 +2014,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/eastasianwidth": {
@@ -2219,36 +2074,6 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
-      }
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/escalade": {
@@ -2411,21 +2236,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/for-each": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
-      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-callable": "^1.2.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -2465,15 +2275,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2494,30 +2295,6 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -2526,19 +2303,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -2585,18 +2349,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2614,65 +2366,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hash-base": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
-      "integrity": "sha512-0TROgQ1/SxE6KmxWSvXHvRj90/Xo1JvZShofnYF+f6ZsGtR4eES7WfrQzPalmyagfKZCXpVnitiRebZulWsbiw==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.1"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
+    "node_modules/hash-wasm": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/hash-wasm/-/hash-wasm-4.12.0.tgz",
+      "integrity": "sha512-+/2B2rYLb48I/evdOIhP+K/DD2ca2fgBjp6O+GBEnCDk2e4rpeXIK8GvIyRPjTezgmWn9gmKwkQjjx6BtqDHVQ==",
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -2737,6 +2435,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/is-arrayish": {
@@ -2745,18 +2444,6 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -2800,27 +2487,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/is-typed-array": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
-      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "which-typed-array": "^1.1.16"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2978,7 +2644,6 @@
       "integrity": "sha512-HlSEiHRcmTuGwNyeawLTEzpQUMFn+f741FfoNg7RXG2h0WLJKozVCpcQLT0GW17H6kNCqRwGf+Ii/I1YVNvEGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.0.2",
         "@jest/types": "30.0.1",
@@ -3726,15 +3391,6 @@
         "tmpl": "1.0.5"
       }
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -4020,23 +3676,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/pbkdf2": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.3.tgz",
-      "integrity": "sha512-wfRLBZ0feWRhCIkoMB6ete7czJcnNnqRpcoWQBLqatqXXmelSRqfdDK4F3u9T2s2cXas/hQJcryI/4lAL+XTlA==",
-      "license": "MIT",
-      "dependencies": {
-        "create-hash": "~1.1.3",
-        "create-hmac": "^1.1.7",
-        "ripemd160": "=2.0.1",
-        "safe-buffer": "^5.2.1",
-        "sha.js": "^2.4.11",
-        "to-buffer": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4078,15 +3717,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/possible-typed-array-names": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
-      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/pretty-format": {
@@ -4174,36 +3804,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ripemd160": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
-      "integrity": "sha512-J7f4wutN8mdbV08MJnXibYpCOPHR+yzy+iQ/AsjMv2j8cLavQ8VGagDFUwwTAdF8FmRKVeNpbTTEwNHCW1g94w==",
-      "license": "MIT",
-      "dependencies": {
-        "hash-base": "^2.0.0",
-        "inherits": "^2.0.1"
-      }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -4212,36 +3812,6 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/sha.js": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-      "license": "(MIT AND BSD-3-Clause)",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      },
-      "bin": {
-        "sha.js": "bin.js"
       }
     },
     "node_modules/shebang-command": {
@@ -4602,20 +4172,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/to-buffer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.1.tgz",
-      "integrity": "sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "isarray": "^2.0.5",
-        "safe-buffer": "^5.2.1",
-        "typed-array-buffer": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4739,27 +4295,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/typed-array-buffer": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
-      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "is-typed-array": "^1.1.14"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4880,27 +4421,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/which-typed-array": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "for-each": "^0.3.5",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/wrap-ansi": {

--- a/js/package.json
+++ b/js/package.json
@@ -29,13 +29,12 @@
   },
   "author": "Quantus Network",
   "license": "MIT",
-  "description": "A tool to generate human-readable checksums from cryptocurrency addresses using the BIP-39 word list and PBKDF2",
+  "description": "A tool to generate human-readable checksums from cryptocurrency addresses using the BIP-39 word list and Argon2id",
   "dependencies": {
-    "pbkdf2": "^3.1.3"
+    "hash-wasm": "^4.12.0"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
-    "@types/pbkdf2": "^3.1.2",
     "jest": "^30.0.2",
     "ts-jest": "^29.4.0",
     "typescript": "^5.8.3"

--- a/js/src/index.spec.ts
+++ b/js/src/index.spec.ts
@@ -1,4 +1,4 @@
-import { addressToChecksum, loadWordList } from "./index";
+import { addressToChecksum, loadWordList, normalizeAddress } from "./index";
 import { readFileSync } from "fs";
 import { join } from "path";
 
@@ -6,6 +6,8 @@ interface TestCase {
   address: string;
   description: string;
   expected: string[];
+  wordCount?: number;
+  context?: string;
 }
 
 interface TestVectors {
@@ -29,14 +31,17 @@ describe("Generate a checksum from an address", () => {
     expect(wordList.length).toBe(2048);
   });
 
-  it("should pass all test vectors", () => {
+  it("should pass all test vectors", async () => {
     console.log(`Running ${testVectors.testCases.length} test vectors...`);
 
     let passed = 0;
     let failed = 0;
 
     for (const testCase of testVectors.testCases) {
-      const checksum = addressToChecksum(testCase.address, wordList);
+      const checksum = await addressToChecksum(testCase.address, wordList, {
+        wordCount: testCase.wordCount,
+        context: testCase.context,
+      });
 
       if (JSON.stringify(checksum) === JSON.stringify(testCase.expected)) {
         passed++;
@@ -51,23 +56,56 @@ describe("Generate a checksum from an address", () => {
 
     console.log(`\nResults: ${passed} passed, ${failed} failed`);
     expect(failed).toBe(0);
-  });
+  }, 120_000);
 
-  it("should generate deterministic checksums", () => {
+  it("should generate deterministic checksums", async () => {
     const address = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa";
-    const checksum1 = addressToChecksum(address, wordList);
-    const checksum2 = addressToChecksum(address, wordList);
+    const checksum1 = await addressToChecksum(address, wordList);
+    const checksum2 = await addressToChecksum(address, wordList);
 
     expect(checksum1).toEqual(checksum2);
-  });
+  }, 30_000);
 
-  it("should return different checksum for different addresses even if only one char differs", () => {
+  it("should return different checksum for different addresses even if only one char differs", async () => {
     const addr1 = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa";
     const addr2 = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DixfNa";
 
-    const checksum1 = addressToChecksum(addr1, wordList);
-    const checksum2 = addressToChecksum(addr2, wordList);
+    const checksum1 = await addressToChecksum(addr1, wordList);
+    const checksum2 = await addressToChecksum(addr2, wordList);
 
     expect(checksum1).not.toEqual(checksum2);
+  }, 30_000);
+
+  it("should normalize hex addresses and whitespace but not base58", () => {
+    expect(normalizeAddress(" 0x742d35Cc6634C0532925a3b844Bc9e7595f5bE21\n")).toBe(
+      "0x742d35cc6634c0532925a3b844bc9e7595f5be21",
+    );
+    expect(normalizeAddress("0X742D35CC6634C0532925A3B844BC9E7595F5BE21")).toBe(
+      "0x742d35cc6634c0532925a3b844bc9e7595f5be21",
+    );
+    expect(normalizeAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa")).toBe(
+      "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+    );
+    expect(normalizeAddress("0xNotHexZZZ")).toBe("0xNotHexZZZ");
   });
+
+  it("should reject invalid word counts", async () => {
+    const address = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa";
+    await expect(
+      addressToChecksum(address, wordList, { wordCount: 2 }),
+    ).rejects.toThrow(RangeError);
+    await expect(
+      addressToChecksum(address, wordList, { wordCount: 12 }),
+    ).rejects.toThrow(RangeError);
+  });
+
+  it("should domain-separate phrases by context", async () => {
+    const address = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa";
+    const plain = await addressToChecksum(address, wordList);
+    const withContext = await addressToChecksum(address, wordList, {
+      context: "bitcoin",
+    });
+
+    expect(withContext).not.toEqual(plain);
+  }, 30_000);
 });

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -1,40 +1,91 @@
-import * as pbkdf2 from "pbkdf2";
+import { argon2id } from "hash-wasm";
 import wordlist from "./wordlist.json";
 
-// Constants
-const SALT = "human-readable-checksum";
-const ITERATIONS = 40_000;
-const CHECKSUM_LEN = 5;
-// Fix: Use Math.ceil to round up to the nearest integer
-const KEY_BYTECOUNT = Math.ceil((CHECKSUM_LEN * 11) / 8);
+// Scheme version string, also used as the Argon2 salt (optionally extended
+// with a domain-separation context: "human-checkphrase-v2|<context>").
+const VERSION = "human-checkphrase-v2";
+
+// Argon2id parameters (RFC 9106), must match all other implementations.
+const MEMORY_KIB = 64 * 1024;
+const TIME_COST = 3;
+const PARALLELISM = 1;
+
+const DEFAULT_WORD_COUNT = 5;
+// Argon2 output must be at least 4 bytes; 3 words -> 5 key bytes.
+const MIN_WORD_COUNT = 3;
+// 11 words = 121 bits; keeps parity with the Rust implementation's u128.
+const MAX_WORD_COUNT = 11;
+
+export interface ChecksumOptions {
+  /** Number of words in the phrase (3-11). Defaults to 5. */
+  wordCount?: number;
+  /**
+   * Optional domain-separation context (e.g. a chain id such as "eip155:1").
+   * Two wallets must use the same context to see the same phrase.
+   */
+  context?: string;
+}
 
 const loadWordList = (): string[] => {
   return wordlist;
 };
 
-const addressToChecksum = (address: string, wordList: string[]) => {
-  // PBKDF2-HMAC-SHA256 using the pbkdf2 package
-  const key = pbkdf2.pbkdf2Sync(
-    address,
-    SALT,
-    ITERATIONS,
-    KEY_BYTECOUNT,
-    "sha256",
-  );
+/**
+ * Canonicalize an address string before hashing.
+ *
+ * Surrounding whitespace is stripped. 0x-prefixed hexadecimal addresses are
+ * lowercased so that EIP-55 checksum casing does not change the checkphrase.
+ * All other encodings (base58, bech32, SS58, ...) are case-sensitive and are
+ * passed through unchanged; callers must supply them in canonical form.
+ */
+const normalizeAddress = (address: string): string => {
+  const trimmed = address.trim();
+  if (/^0[xX][0-9a-fA-F]+$/.test(trimmed)) {
+    return trimmed.toLowerCase();
+  }
+  return trimmed;
+};
+
+const addressToChecksum = async (
+  address: string,
+  wordList: string[],
+  options: ChecksumOptions = {},
+): Promise<string[]> => {
+  const wordCount = options.wordCount ?? DEFAULT_WORD_COUNT;
+  if (wordCount < MIN_WORD_COUNT || wordCount > MAX_WORD_COUNT) {
+    throw new RangeError(
+      `wordCount must be between ${MIN_WORD_COUNT} and ${MAX_WORD_COUNT}, got ${wordCount}`,
+    );
+  }
+
+  const keyByteCount = Math.ceil((wordCount * 11) / 8);
+  const salt = options.context ? `${VERSION}|${options.context}` : VERSION;
+
+  // Argon2id: memory-hard KDF so that GPU/ASIC farms cannot grind
+  // checkphrase collisions much faster than commodity hardware.
+  const key = await argon2id({
+    password: normalizeAddress(address),
+    salt,
+    iterations: TIME_COST,
+    memorySize: MEMORY_KIB,
+    parallelism: PARALLELISM,
+    hashLength: keyByteCount,
+    outputType: "binary",
+  });
 
   // Convert key bytes to a big integer (using BigInt for arbitrary precision)
   let keyInt = 0n;
-  for (let i = 0; i < KEY_BYTECOUNT && i < key.length; i++) {
+  for (let i = 0; i < keyByteCount; i++) {
     keyInt = (keyInt << 8n) | BigInt(key[i]);
   }
 
-  // Take only the first CHECKSUM_LEN * 11 bits
-  keyInt >>= BigInt((8 * KEY_BYTECOUNT) % 11);
+  // Take only the first wordCount * 11 bits
+  keyInt >>= BigInt((8 * keyByteCount) % 11);
 
   // Split into 11-bit indices
   const indices: number[] = [];
-  for (let i = 0; i < CHECKSUM_LEN; i++) {
-    const shift = BigInt((CHECKSUM_LEN - 1 - i) * 11);
+  for (let i = 0; i < wordCount; i++) {
+    const shift = BigInt((wordCount - 1 - i) * 11);
     const index = Number((keyInt >> shift) & 0x7ffn);
     indices.push(index);
   }
@@ -43,4 +94,4 @@ const addressToChecksum = (address: string, wordList: string[]) => {
   return indices.map((i) => wordList[i]);
 };
 
-export { loadWordList, addressToChecksum };
+export { loadWordList, normalizeAddress, addressToChecksum, VERSION };

--- a/scripts/checkphrase.py
+++ b/scripts/checkphrase.py
@@ -1,0 +1,82 @@
+"""
+Reference implementation of the human-checkphrase v2 scheme.
+
+Scheme (must match the Rust, JavaScript and Dart implementations):
+
+1. Normalize the address string:
+   - strip leading/trailing whitespace
+   - if the address is 0x-prefixed hexadecimal, lowercase it (EIP-55 casing
+     must not change the checkphrase); all other encodings are case-sensitive
+     and passed through unchanged
+2. Derive key bytes with Argon2id (RFC 9106):
+   - memory = 64 MiB, time cost = 3, parallelism = 1, version 0x13
+   - salt = "human-checkphrase-v2", or "human-checkphrase-v2|<context>" when
+     a domain-separation context (e.g. a chain id) is supplied
+   - output length = ceil(word_count * 11 / 8) bytes
+3. Interpret the key bytes as a big-endian integer, drop the
+   (8 * key_len) % 11 low bits, and split the remainder into word_count
+   11-bit indices into the 2048-word list.
+"""
+
+import re
+
+from argon2.low_level import Type, hash_secret_raw
+
+VERSION = "human-checkphrase-v2"
+MEMORY_KIB = 65536  # 64 MiB
+TIME_COST = 3
+PARALLELISM = 1
+DEFAULT_WORD_COUNT = 5
+# Argon2 requires at least 4 output bytes; 3 words -> ceil(33/8) = 5 bytes.
+MIN_WORD_COUNT = 3
+MAX_WORD_COUNT = 11
+
+_HEX_ADDRESS_RE = re.compile(r"0[xX][0-9a-fA-F]+\Z")
+
+
+def normalize_address(address: str) -> str:
+    """Canonicalize an address string before hashing."""
+    stripped = address.strip()
+    if _HEX_ADDRESS_RE.fullmatch(stripped):
+        return stripped.lower()
+    return stripped
+
+
+def checkphrase_salt(context: str | None = None) -> str:
+    """Versioned salt, optionally domain-separated by a chain context."""
+    if context:
+        return f"{VERSION}|{context}"
+    return VERSION
+
+
+def address_to_checksum(
+    address: str,
+    word_list: list[str],
+    word_count: int = DEFAULT_WORD_COUNT,
+    context: str | None = None,
+) -> list[str]:
+    """Generate a human-readable checkphrase for an address."""
+    if not MIN_WORD_COUNT <= word_count <= MAX_WORD_COUNT:
+        raise ValueError(
+            f"word_count must be between {MIN_WORD_COUNT} and {MAX_WORD_COUNT}"
+        )
+
+    key_len = (word_count * 11 + 7) // 8
+    key = hash_secret_raw(
+        secret=normalize_address(address).encode("utf-8"),
+        salt=checkphrase_salt(context).encode("utf-8"),
+        time_cost=TIME_COST,
+        memory_cost=MEMORY_KIB,
+        parallelism=PARALLELISM,
+        hash_len=key_len,
+        type=Type.ID,
+    )
+
+    key_int = int.from_bytes(key, "big") >> (8 * key_len) % 11
+
+    indices = []
+    for i in range(word_count):
+        shift = (word_count - 1 - i) * 11
+        indices.append((key_int >> shift) & 0x7FF)
+
+    return [word_list[i] for i in indices]

--- a/scripts/generate_test_vectors.py
+++ b/scripts/generate_test_vectors.py
@@ -2,25 +2,28 @@
 """
 Generate test vectors for cross-platform validation of human-checkphrase.
 
-This script generates 1000 test vectors using random addresses to ensure
-comprehensive coverage of the wordlist. The vectors are saved to
-test-vectors/checksums.json and serve as the source of truth for all
-implementations (Rust, JavaScript, Dart).
+The vectors are saved to test-vectors/checksums.json and serve as the source
+of truth for all implementations (Rust, JavaScript, Dart). Each test case may
+carry optional "wordCount" and "context" fields; implementations must default
+to wordCount=5 and no context when the fields are absent.
+
+Requires argon2-cffi:  pip install argon2-cffi
 """
 
-import hashlib
 import json
-import os
 import random
 import string
 import sys
 from pathlib import Path
 
-# Constants (must match all implementations)
-SALT = b'human-readable-checksum'
-ITERATIONS = 40000
-CHECKSUM_LEN = 5
-KEY_BYTECOUNT = (CHECKSUM_LEN * 11 + 7) // 8
+from checkphrase import (
+    DEFAULT_WORD_COUNT,
+    MEMORY_KIB,
+    PARALLELISM,
+    TIME_COST,
+    VERSION,
+    address_to_checksum,
+)
 
 # Paths
 SCRIPT_DIR = Path(__file__).parent
@@ -28,37 +31,18 @@ REPO_ROOT = SCRIPT_DIR.parent
 WORDLIST_PATH = REPO_ROOT / 'final_wordlist.txt'
 OUTPUT_PATH = REPO_ROOT / 'test-vectors' / 'checksums.json'
 
+RANDOM_VECTOR_COUNT = 128
+
 
 def load_wordlist() -> list[str]:
     """Load the canonical wordlist from the repo root."""
     with open(WORDLIST_PATH, 'r') as f:
         words = [line.strip() for line in f if line.strip()]
-    
+
     if len(words) != 2048:
         raise ValueError(f"Wordlist must have exactly 2048 words, found {len(words)}")
-    
+
     return words
-
-
-def address_to_checksum(address: str, word_list: list[str]) -> list[str]:
-    """Generate a checksum from an address using PBKDF2."""
-    key = hashlib.pbkdf2_hmac(
-        'sha256',
-        address.encode('utf-8'),
-        SALT,
-        ITERATIONS,
-        dklen=KEY_BYTECOUNT
-    )
-    
-    key_int = int.from_bytes(key, 'big') >> (8 * KEY_BYTECOUNT) % 11
-    
-    indices = []
-    for i in range(CHECKSUM_LEN):
-        shift = (CHECKSUM_LEN - 1 - i) * 11
-        index = (key_int >> shift) & 0x7FF
-        indices.append(index)
-    
-    return [word_list[i] for i in indices]
 
 
 def generate_random_address(prefix: str = "", length: int = 40) -> str:
@@ -68,22 +52,27 @@ def generate_random_address(prefix: str = "", length: int = 40) -> str:
     return prefix + random_part
 
 
-def generate_test_vectors(word_list: list[str], count: int = 1000, ensure_full_coverage: bool = True) -> tuple[list[dict], set[str]]:
-    """
-    Generate test vectors ensuring comprehensive word coverage.
-    
-    Strategy:
-    1. Include canonical examples from README (9 vectors)
-    2. Generate random addresses until we've seen all 2048 words
-    3. Continue until we reach the target count
-    
-    If ensure_full_coverage is True, will generate extra vectors beyond count
-    to ensure all words are covered at least once.
-    """
+def make_case(word_list, address, description, word_count=None, context=None):
+    case = {
+        "address": address,
+        "description": description,
+        "expected": address_to_checksum(
+            address,
+            word_list,
+            word_count=word_count or DEFAULT_WORD_COUNT,
+            context=context,
+        ),
+    }
+    if word_count is not None:
+        case["wordCount"] = word_count
+    if context is not None:
+        case["context"] = context
+    return case
+
+
+def generate_test_vectors(word_list: list[str]) -> list[dict]:
     vectors = []
-    words_seen = set()
-    all_words = set(word_list)
-    
+
     # Canonical examples from README (these must always be included)
     canonical_addresses = [
         ("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", "Bitcoin - Satoshi's address"),
@@ -96,18 +85,45 @@ def generate_test_vectors(word_list: list[str], count: int = 1000, ensure_full_c
         ("qzkABCDEF123456789abcdefGHIJKLMNOPQRSTUVWXYZ000001", "Quantus 2"),
         ("qzkXyZ987654321FeDcBaAbCdEfGhIjKlMnOpQrStUvWxYz99", "Quantus 3"),
     ]
-    
-    # Add canonical examples first
     for address, description in canonical_addresses:
-        checksum = address_to_checksum(address, word_list)
-        vectors.append({
-            "address": address,
-            "description": description,
-            "expected": checksum
-        })
-        words_seen.update(checksum)
-    
-    # Address prefixes to simulate different chains
+        vectors.append(make_case(word_list, address, description))
+
+    # Normalization: these must match the canonical Ethereum vector above.
+    eth = "0x742d35Cc6634C0532925a3b844Bc9e7595f5bE21"
+    vectors.append(make_case(
+        word_list, eth.lower(),
+        "Normalization - Ethereum all-lowercase (same phrase as EIP-55 form)"))
+    vectors.append(make_case(
+        word_list, "0X" + eth[2:].upper(),
+        "Normalization - Ethereum 0X-uppercase (same phrase as EIP-55 form)"))
+    vectors.append(make_case(
+        word_list, f"  {eth}\n",
+        "Normalization - surrounding whitespace is stripped"))
+    # Base58 is case-sensitive: no lowercasing must be applied.
+    vectors.append(make_case(
+        word_list, "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa".lower(),
+        "Normalization - lowercased base58 is a DIFFERENT address/phrase"))
+
+    # Non-default word counts.
+    for wc in (3, 4, 6, 8, 11):
+        vectors.append(make_case(
+            word_list, "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+            f"Word count {wc} - Satoshi's address", word_count=wc))
+
+    # Domain-separation context (e.g. a chain id).
+    vectors.append(make_case(
+        word_list, "qzk7h3xH4Fmv2RqKpN8sT5jW9cY6gB1dL3mX0vQwEaUoZrJtS",
+        "Context 'quantus' - salt becomes 'human-checkphrase-v2|quantus'",
+        context="quantus"))
+    vectors.append(make_case(
+        word_list, "0x742d35Cc6634C0532925a3b844Bc9e7595f5bE21",
+        "Context 'eip155:1' - Ethereum mainnet domain separation",
+        context="eip155:1"))
+    vectors.append(make_case(
+        word_list, "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+        "Context 'bitcoin' with word count 8", word_count=8, context="bitcoin"))
+
+    # Random addresses across chain-style prefixes.
     prefixes = [
         "0x",           # Ethereum-style
         "1",            # Bitcoin legacy
@@ -119,101 +135,65 @@ def generate_test_vectors(word_list: list[str], count: int = 1000, ensure_full_c
         "qzk",          # Quantus
         "",             # Generic
     ]
-    
+
     # Use a fixed seed for reproducibility
     random.seed(42)
-    
-    vector_num = len(vectors)
-    attempts = 0
-    max_attempts = count * 1000  # Safety limit (increased for full coverage)
-    
-    while attempts < max_attempts:
-        attempts += 1
-        
-        # Pick a random prefix
+
+    for i in range(RANDOM_VECTOR_COUNT):
         prefix = random.choice(prefixes)
         length = random.randint(30, 64)
         address = generate_random_address(prefix, length)
-        
-        checksum = address_to_checksum(address, word_list)
-        
-        # Track which words we've seen
-        new_words = set(checksum) - words_seen
-        
-        # Determine if we should add this vector
-        need_more_vectors = len(vectors) < count
-        need_more_coverage = ensure_full_coverage and words_seen != all_words
-        has_new_words = len(new_words) > 0
-        
-        # Add if we need more vectors, or if this gives us new word coverage
-        if need_more_vectors or (need_more_coverage and has_new_words):
-            vector_num += 1
-            vectors.append({
-                "address": address,
-                "description": f"Generated test vector #{vector_num}",
-                "expected": checksum
-            })
-            words_seen.update(checksum)
-        
-        # Stop if we've hit count AND have full coverage (or don't need it)
-        have_enough_vectors = len(vectors) >= count
-        have_full_coverage = words_seen == all_words
-        if have_enough_vectors and (have_full_coverage or not ensure_full_coverage):
-            break
-    
-    return vectors, words_seen
+        vectors.append(make_case(
+            word_list, address, f"Generated test vector #{i + 1}"))
+
+    return vectors
 
 
 def main():
     print("Loading canonical wordlist...")
     word_list = load_wordlist()
     print(f"Loaded {len(word_list)} words")
-    
-    print("\nGenerating test vectors...")
-    vectors, words_seen = generate_test_vectors(word_list, count=1000)
-    
-    # Check word coverage
-    all_words = set(word_list)
-    missing_words = all_words - words_seen
-    coverage = len(words_seen) / len(all_words) * 100
-    
+
+    print("\nGenerating test vectors (Argon2id is intentionally slow)...")
+    vectors = generate_test_vectors(word_list)
+
+    words_seen = set()
+    for case in vectors:
+        words_seen.update(case["expected"])
+    coverage = len(words_seen) / len(word_list) * 100
+
     print(f"\nGenerated {len(vectors)} test vectors")
-    print(f"Word coverage: {len(words_seen)}/{len(all_words)} ({coverage:.1f}%)")
-    
-    if missing_words:
-        print(f"Missing {len(missing_words)} words: {sorted(missing_words)[:20]}...")
-    else:
-        print("Full word coverage achieved!")
-    
-    # Create output structure
+    print(f"Word coverage: {len(words_seen)}/{len(word_list)} ({coverage:.1f}%)")
+
     output = {
-        "version": "1.0",
+        "version": "2.0",
         "description": "Cross-platform test vectors for human-checkphrase",
         "generated_by": "scripts/generate_test_vectors.py",
         "constants": {
-            "salt": SALT.decode('utf-8'),
-            "iterations": ITERATIONS,
-            "checksumLength": CHECKSUM_LEN
+            "kdf": "argon2id",
+            "argon2Version": 19,
+            "memoryKiB": MEMORY_KIB,
+            "timeCost": TIME_COST,
+            "parallelism": PARALLELISM,
+            "salt": VERSION,
+            "defaultWordCount": DEFAULT_WORD_COUNT,
         },
         "statistics": {
             "totalVectors": len(vectors),
             "wordsCovered": len(words_seen),
-            "totalWords": len(all_words),
-            "coveragePercent": round(coverage, 2)
+            "totalWords": len(word_list),
+            "coveragePercent": round(coverage, 2),
         },
-        "testCases": vectors
+        "testCases": vectors,
     }
-    
-    # Ensure output directory exists
+
     OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
-    
-    # Write output
+
     with open(OUTPUT_PATH, 'w') as f:
         json.dump(output, f, indent=2)
-    
+
     print(f"\nSaved test vectors to {OUTPUT_PATH}")
-    
-    return 0 if not missing_words else 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,4 @@
+argon2-cffi==25.1.0
 certifi==2025.1.31
 charset-normalizer==3.4.1
 idna==3.10

--- a/scripts/words.py
+++ b/scripts/words.py
@@ -1,73 +1,26 @@
-import requests
-import hashlib
-import hmac
-import os
+"""Prototype/demo script: print checkphrases for a couple of test addresses.
 
-# Constants
-WORD_LIST_FILE = 'final_wordlist.txt'
-BIP39_URL = "https://raw.githubusercontent.com/bitcoin/bips/master/bip-0039/english.txt"
-ITERATIONS = 40000
-SALT = b'human-readable-checksum'
-CHECKSUM_LEN = 5
-KEY_BYTECOUNT = (CHECKSUM_LEN * 11 + 7) // 8
+The actual scheme lives in checkphrase.py; this file just exercises it.
+"""
+
+from pathlib import Path
+
+from checkphrase import address_to_checksum
+
+WORD_LIST_FILE = Path(__file__).parent.parent / 'final_wordlist.txt'
 
 
-# Fetch or load BIP-39 list
-def load_bip39_list(local_file=WORD_LIST_FILE, url=BIP39_URL):
-    """Load the BIP-39 list from local file if it exists, otherwise fetch it."""
-    # Check if local file exists and has content
-    if os.path.exists(local_file) and os.path.getsize(local_file) > 0:
-        with open(local_file, 'r') as f:
-            words = [line.strip() for line in f]
-        if len(words) == 2048:  # Verify it’s the full list
-            print(f"Loaded {len(words)} words from {local_file}")
-            return words
-        else:
-            print(f"Local file {local_file} is incomplete, re-downloading...")
+def load_word_list():
+    with open(WORD_LIST_FILE, 'r') as f:
+        words = [line.strip() for line in f if line.strip()]
+    if len(words) != 2048:
+        raise ValueError(f"Expected 2048 words, found {len(words)}")
+    print(f"Loaded {len(words)} words from {WORD_LIST_FILE}")
+    return words
 
-    # Fetch from URL if local file is missing or invalid
-    response = requests.get(url)
-    if response.status_code == 200:
-        words = response.text.strip().split('\n')
-        if len(words) == 2048:
-            save_word_list(words, local_file)  # Save for next time
-            return words
-    raise Exception("Failed to fetch or validate BIP-39 list")
-
-# PBKDF2-based checksum
-def address_to_checksum(address, word_list):
-    """Generate a four-word checksum from an address using PBKDF2."""
-    key = hashlib.pbkdf2_hmac(
-        'sha256',
-        address.encode('utf-8'),
-        SALT,
-        ITERATIONS,
-        dklen=KEY_BYTECOUNT
-    )
-    print("key {}".format(key.hex()))
-    key_int = int.from_bytes(key, 'big') >> (8 * KEY_BYTECOUNT) % 11
-    print("key_int {}".format(key_int))
-    indices = []
-    for i in range(CHECKSUM_LEN):
-        shift = (CHECKSUM_LEN - 1 - i) * 11
-        index = (key_int >> shift) & 0x7FF
-        indices.append(index)
-
-    print("indices {}".format(indices))
-    return [word_list[i] for i in indices]
-
-def save_word_list(word_list, output_file=WORD_LIST_FILE):
-    """Save the word list to a file."""
-    with open(output_file, 'w') as f:
-        for word in word_list:
-            f.write(word + '\n')
-    print(f"Saved {len(word_list)} words to {output_file}")
 
 def main():
-    # Load or fetch BIP-39 list
-    bip39_list = load_bip39_list()
-    print(f"Total combos: {len(bip39_list)**CHECKSUM_LEN:,}")
-    print(f"Sample: {bip39_list[:CHECKSUM_LEN]} ... {bip39_list[-CHECKSUM_LEN:]}")
+    word_list = load_word_list()
 
     # Test addresses
     test_addresses = [
@@ -75,9 +28,10 @@ def main():
         "1A1zP1eP5QGefi2DMPTfTL5SLmv7DixfNa"   # Poisoned
     ]
     for addr in test_addresses:
-        four_words = address_to_checksum(addr, bip39_list)
+        words = address_to_checksum(addr, word_list)
         print(f"Address: {addr}")
-        print(f"Checksum: {'-'.join(four_words)}")
+        print(f"Checkphrase: {'-'.join(words)}")
+
 
 if __name__ == "__main__":
     main()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,53 @@
 use std::{
+	fmt,
 	fs::File,
 	io::{self, BufRead, BufReader},
 	path::Path,
 };
 
-use pbkdf2::pbkdf2_hmac;
-use sha2::Sha256;
+use argon2::{Algorithm, Argon2, Params, Version};
 
 // Constants
 const WORD_LIST_FILE: &str = "final_wordlist.txt";
-const WORD_COUNT: usize = 2048;
-const SALT: &str = "human-readable-checksum";
-const ITERATIONS: u32 = 40000;
-const CHECKSUM_LEN: usize = 5;
-const KEY_BYTECOUNT: usize = (CHECKSUM_LEN * 11).div_ceil(8);
+const WORD_LIST_SIZE: usize = 2048;
+
+/// Scheme version string, also used as the Argon2 salt (optionally extended
+/// with a domain-separation context: "human-checkphrase-v2|<context>").
+pub const VERSION: &str = "human-checkphrase-v2";
+
+// Argon2id parameters (RFC 9106). Memory-hardness is what keeps GPU/ASIC
+// grinding attacks close to defender cost, so prefer raising memory over
+// iterations if these are ever tuned.
+const MEMORY_KIB: u32 = 64 * 1024;
+const TIME_COST: u32 = 3;
+const PARALLELISM: u32 = 1;
+
+pub const DEFAULT_WORD_COUNT: usize = 5;
+/// Argon2 output must be at least 4 bytes; 3 words -> 5 key bytes.
+pub const MIN_WORD_COUNT: usize = 3;
+/// 11 words = 121 bits, the most that fits in the u128 used for bit slicing.
+pub const MAX_WORD_COUNT: usize = 11;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ChecksumError {
+	InvalidWordCount(usize),
+	Kdf(String),
+}
+
+impl fmt::Display for ChecksumError {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			ChecksumError::InvalidWordCount(n) => write!(
+				f,
+				"word count must be between {} and {}, got {}",
+				MIN_WORD_COUNT, MAX_WORD_COUNT, n
+			),
+			ChecksumError::Kdf(e) => write!(f, "key derivation failed: {}", e),
+		}
+	}
+}
+
+impl std::error::Error for ChecksumError {}
 
 pub fn load_word_list() -> io::Result<Vec<String>> {
 	if !Path::new(WORD_LIST_FILE).exists() {
@@ -27,45 +61,90 @@ pub fn load_word_list() -> io::Result<Vec<String>> {
 	let reader = BufReader::new(file);
 	let words: Vec<String> = reader.lines().collect::<io::Result<_>>()?;
 
-	if words.len() != WORD_COUNT {
+	if words.len() != WORD_LIST_SIZE {
 		return Err(io::Error::new(
 			io::ErrorKind::InvalidData,
-			format!("Word list must contain exactly {} words, found {}", WORD_COUNT, words.len()),
+			format!("Word list must contain exactly {} words, found {}", WORD_LIST_SIZE, words.len()),
 		));
 	}
 
-	println!("Loaded {} words from {}", words.len(), WORD_LIST_FILE);
 	Ok(words)
 }
 
-pub fn address_to_checksum(address: &str, word_list: &[String]) -> Vec<String> {
-	// PBKDF2-HMAC-SHA256
-	let mut key = [0u8; KEY_BYTECOUNT];
-	pbkdf2_hmac::<Sha256>(address.as_bytes(), SALT.as_bytes(), ITERATIONS, &mut key);
-	// println!("Key : {}", hex::encode(&key));
+/// Canonicalize an address string before hashing.
+///
+/// Surrounding whitespace is stripped. 0x-prefixed hexadecimal addresses are
+/// lowercased so that EIP-55 checksum casing does not change the checkphrase.
+/// All other encodings (base58, bech32, SS58, ...) are case-sensitive and are
+/// passed through unchanged; callers must supply them in canonical form.
+pub fn normalize_address(address: &str) -> String {
+	let trimmed = address.trim();
+	let is_hex = trimmed.len() > 2
+		&& (trimmed.starts_with("0x") || trimmed.starts_with("0X"))
+		&& trimmed[2..].bytes().all(|b| b.is_ascii_hexdigit());
+	if is_hex {
+		trimmed.to_ascii_lowercase()
+	} else {
+		trimmed.to_string()
+	}
+}
 
-	// Convert key bytes to a big integer
-	let mut key_int = 0u128; // Using u128 to handle larger checksum lengths
-	for &byte in key.iter().take(KEY_BYTECOUNT) {
+/// Generate a checkphrase with the default word count (5) and no context.
+///
+/// Panics only if the word list is shorter than 2048 entries; use
+/// [`load_word_list`] to obtain a validated list.
+pub fn address_to_checksum(address: &str, word_list: &[String]) -> Vec<String> {
+	address_to_checksum_with_options(address, word_list, DEFAULT_WORD_COUNT, None)
+		.expect("default word count is valid")
+}
+
+/// Generate a checkphrase of `word_count` words, optionally domain-separated
+/// by `context` (e.g. a chain id such as "eip155:1"). Two wallets must use
+/// the same context string to see the same phrase for an address.
+pub fn address_to_checksum_with_options(
+	address: &str,
+	word_list: &[String],
+	word_count: usize,
+	context: Option<&str>,
+) -> Result<Vec<String>, ChecksumError> {
+	if !(MIN_WORD_COUNT..=MAX_WORD_COUNT).contains(&word_count) {
+		return Err(ChecksumError::InvalidWordCount(word_count));
+	}
+
+	let key_bytecount = (word_count * 11).div_ceil(8);
+	let salt = match context {
+		Some(ctx) if !ctx.is_empty() => format!("{}|{}", VERSION, ctx),
+		_ => VERSION.to_string(),
+	};
+
+	// Argon2id: memory-hard KDF so that GPU/ASIC farms cannot grind
+	// checkphrase collisions much faster than commodity hardware.
+	let params = Params::new(MEMORY_KIB, TIME_COST, PARALLELISM, Some(key_bytecount))
+		.map_err(|e| ChecksumError::Kdf(e.to_string()))?;
+	let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
+
+	let mut key = vec![0u8; key_bytecount];
+	argon2
+		.hash_password_into(normalize_address(address).as_bytes(), salt.as_bytes(), &mut key)
+		.map_err(|e| ChecksumError::Kdf(e.to_string()))?;
+
+	// Convert key bytes to a big integer (u128 fits up to 11 words = 121 bits)
+	let mut key_int = 0u128;
+	for &byte in &key {
 		key_int = (key_int << 8) | byte as u128;
 	}
 
-	// take only the first CHECKSUM_LEN * 11 bits
-	key_int >>= (8 * KEY_BYTECOUNT) % 11;
-	// println!("Key Int: {}", &key_int);
-	// key_int &= (1 << (CHECKSUM_LEN * 11)) - 1;
+	// take only the first word_count * 11 bits
+	key_int >>= (8 * key_bytecount) % 11;
 
-	// Split into 11-bit indices
-	let mut indices = Vec::with_capacity(CHECKSUM_LEN);
-	for i in 0..CHECKSUM_LEN {
-		let shift = (CHECKSUM_LEN - 1 - i) * 11;
+	// Split into 11-bit indices and map to words
+	let mut words = Vec::with_capacity(word_count);
+	for i in 0..word_count {
+		let shift = (word_count - 1 - i) * 11;
 		let index = ((key_int >> shift) & 0x7FF) as usize;
-		indices.push(index);
+		words.push(word_list[index].clone());
 	}
-	// println!("Indexes: {:?}", indices);
-
-	// Map to words
-	indices.iter().map(|&i| word_list[i].clone()).collect()
+	Ok(words)
 }
 
 #[cfg(test)]
@@ -87,6 +166,9 @@ mod tests {
 		address: String,
 		description: String,
 		expected: Vec<String>,
+		#[serde(rename = "wordCount")]
+		word_count: Option<usize>,
+		context: Option<String>,
 	}
 
 	fn load_test_vectors() -> TestVectors {
@@ -106,7 +188,14 @@ mod tests {
 		let mut failed = 0;
 
 		for case in &vectors.test_cases {
-			let checksum = address_to_checksum(&case.address, &word_list);
+			let word_count = case.word_count.unwrap_or(DEFAULT_WORD_COUNT);
+			let checksum = address_to_checksum_with_options(
+				&case.address,
+				&word_list,
+				word_count,
+				case.context.as_deref(),
+			)
+			.expect("valid test vector options");
 
 			if checksum == case.expected {
 				passed += 1;
@@ -128,7 +217,12 @@ mod tests {
 	#[test]
 	fn test_wordlist_size() -> io::Result<()> {
 		let word_list = load_word_list()?;
-		assert_eq!(word_list.len(), WORD_COUNT, "Wordlist must have exactly {} words", WORD_COUNT);
+		assert_eq!(
+			word_list.len(),
+			WORD_LIST_SIZE,
+			"Wordlist must have exactly {} words",
+			WORD_LIST_SIZE
+		);
 		Ok(())
 	}
 
@@ -156,6 +250,66 @@ mod tests {
 		let checksum2 = address_to_checksum(addr2, &word_list);
 
 		assert_ne!(checksum1, checksum2, "Different addresses should produce different checksums");
+		Ok(())
+	}
+
+	#[test]
+	fn test_normalization() {
+		// EIP-55 casing and surrounding whitespace must not change the phrase
+		assert_eq!(
+			normalize_address(" 0x742d35Cc6634C0532925a3b844Bc9e7595f5bE21\n"),
+			"0x742d35cc6634c0532925a3b844bc9e7595f5be21"
+		);
+		assert_eq!(
+			normalize_address("0X742D35CC6634C0532925A3B844BC9E7595F5BE21"),
+			"0x742d35cc6634c0532925a3b844bc9e7595f5be21"
+		);
+		// base58 is case-sensitive and must pass through unchanged
+		assert_eq!(
+			normalize_address("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"),
+			"1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"
+		);
+		// non-hex 0x strings are not lowercased
+		assert_eq!(normalize_address("0xNotHexZZZ"), "0xNotHexZZZ");
+	}
+
+	#[test]
+	fn test_invalid_word_counts_rejected() -> io::Result<()> {
+		let word_list = load_word_list()?;
+		let address = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa";
+
+		for bad in [0, MIN_WORD_COUNT - 1, MAX_WORD_COUNT + 1] {
+			let result = address_to_checksum_with_options(address, &word_list, bad, None);
+			assert_eq!(result, Err(ChecksumError::InvalidWordCount(bad)));
+		}
+		Ok(())
+	}
+
+	#[test]
+	fn test_context_changes_phrase() -> io::Result<()> {
+		let word_list = load_word_list()?;
+		let address = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa";
+
+		let plain =
+			address_to_checksum_with_options(address, &word_list, DEFAULT_WORD_COUNT, None)
+				.unwrap();
+		let ctx = address_to_checksum_with_options(
+			address,
+			&word_list,
+			DEFAULT_WORD_COUNT,
+			Some("bitcoin"),
+		)
+		.unwrap();
+		assert_ne!(plain, ctx, "Context should domain-separate phrases");
+
+		let empty_ctx = address_to_checksum_with_options(
+			address,
+			&word_list,
+			DEFAULT_WORD_COUNT,
+			Some(""),
+		)
+		.unwrap();
+		assert_eq!(plain, empty_ctx, "Empty context should equal no context");
 		Ok(())
 	}
 }

--- a/test-vectors/checksums.json
+++ b/test-vectors/checksums.json
@@ -1,12898 +1,1679 @@
 {
-  "version": "1.0",
+  "version": "2.0",
   "description": "Cross-platform test vectors for human-checkphrase",
   "generated_by": "scripts/generate_test_vectors.py",
   "constants": {
-    "salt": "human-readable-checksum",
-    "iterations": 40000,
-    "checksumLength": 5
+    "kdf": "argon2id",
+    "argon2Version": 19,
+    "memoryKiB": 65536,
+    "timeCost": 3,
+    "parallelism": 1,
+    "salt": "human-checkphrase-v2",
+    "defaultWordCount": 5
   },
   "statistics": {
-    "totalVectors": 1171,
-    "wordsCovered": 2048,
+    "totalVectors": 149,
+    "wordsCovered": 624,
     "totalWords": 2048,
-    "coveragePercent": 100.0
+    "coveragePercent": 30.47
   },
   "testCases": [
     {
       "address": "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
       "description": "Bitcoin - Satoshi's address",
       "expected": [
-        "ahead",
-        "aware",
-        "sea",
-        "blockbuster",
-        "hedgehog"
+        "cake",
+        "stuff",
+        "nerve",
+        "job",
+        "subway"
       ]
     },
     {
       "address": "1A1zP1eP5QGefi2DMPTfTL5SLmv7DixfNa",
       "description": "Bitcoin - poisoned variant",
       "expected": [
-        "initial",
-        "flair",
-        "jovial",
-        "broom",
-        "supreme"
+        "polar",
+        "pet",
+        "music",
+        "already",
+        "act"
       ]
     },
     {
       "address": "0x742d35Cc6634C0532925a3b844Bc9e7595f5bE21",
       "description": "Ethereum",
       "expected": [
-        "dog",
-        "cricket",
-        "basket",
-        "obvious",
-        "expire"
+        "meaningful",
+        "curve",
+        "raccoon",
+        "festival",
+        "scan"
       ]
     },
     {
       "address": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
       "description": "Polkadot",
       "expected": [
-        "mention",
-        "boring",
-        "switch",
-        "indicate",
-        "tornado"
+        "cricket",
+        "rare",
+        "significant",
+        "above",
+        "grateful"
       ]
     },
     {
       "address": "cosmos1hsk6jryyqjfhp5dhc55tc9jtckygx0eph6dd02",
       "description": "Cosmos",
       "expected": [
-        "finish",
-        "frisky",
-        "base",
-        "remember",
-        "answer"
+        "dash",
+        "health",
+        "unfazed",
+        "section",
+        "ivory"
       ]
     },
     {
       "address": "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
       "description": "Bitcoin bech32",
       "expected": [
-        "video",
-        "stake",
-        "salient",
-        "immaculate",
-        "climb"
+        "history",
+        "unbound",
+        "fix",
+        "add",
+        "alter"
       ]
     },
     {
       "address": "qzk7h3xH4Fmv2RqKpN8sT5jW9cY6gB1dL3mX0vQwEaUoZrJtS",
       "description": "Quantus 1",
       "expected": [
-        "until",
-        "business",
-        "amazing",
-        "silk",
-        "satoshi"
+        "mimic",
+        "advance",
+        "satisfy",
+        "unusual",
+        "tell"
       ]
     },
     {
       "address": "qzkABCDEF123456789abcdefGHIJKLMNOPQRSTUVWXYZ000001",
       "description": "Quantus 2",
       "expected": [
-        "parade",
-        "invest",
-        "spice",
-        "supply",
-        "devote"
+        "gap",
+        "puppy",
+        "cipher",
+        "topic",
+        "food"
       ]
     },
     {
       "address": "qzkXyZ987654321FeDcBaAbCdEfGhIjKlMnOpQrStUvWxYz99",
       "description": "Quantus 3",
       "expected": [
-        "impeccable",
-        "extend",
-        "bar",
-        "click",
-        "tennis"
+        "cycle",
+        "boost",
+        "sustain",
+        "exuberance",
+        "course"
       ]
     },
     {
-      "address": "1TpigTHKbfoLISRABr1VjArnVgxwvqc",
-      "description": "Generated test vector #10",
+      "address": "0x742d35cc6634c0532925a3b844bc9e7595f5be21",
+      "description": "Normalization - Ethereum all-lowercase (same phrase as EIP-55 form)",
       "expected": [
-        "year",
-        "curious",
-        "brave",
-        "aware",
-        "witness"
+        "meaningful",
+        "curve",
+        "raccoon",
+        "festival",
+        "scan"
+      ]
+    },
+    {
+      "address": "0X742D35CC6634C0532925A3B844BC9E7595F5BE21",
+      "description": "Normalization - Ethereum 0X-uppercase (same phrase as EIP-55 form)",
+      "expected": [
+        "meaningful",
+        "curve",
+        "raccoon",
+        "festival",
+        "scan"
+      ]
+    },
+    {
+      "address": "  0x742d35Cc6634C0532925a3b844Bc9e7595f5bE21\n",
+      "description": "Normalization - surrounding whitespace is stripped",
+      "expected": [
+        "meaningful",
+        "curve",
+        "raccoon",
+        "festival",
+        "scan"
+      ]
+    },
+    {
+      "address": "1a1zp1ep5qgefi2dmptftl5slmv7divfna",
+      "description": "Normalization - lowercased base58 is a DIFFERENT address/phrase",
+      "expected": [
+        "taste",
+        "orangutan",
+        "build",
+        "return",
+        "where"
+      ]
+    },
+    {
+      "address": "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+      "description": "Word count 3 - Satoshi's address",
+      "expected": [
+        "now",
+        "door",
+        "essay"
+      ],
+      "wordCount": 3
+    },
+    {
+      "address": "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+      "description": "Word count 4 - Satoshi's address",
+      "expected": [
+        "resemble",
+        "endorse",
+        "reunion",
+        "busy"
+      ],
+      "wordCount": 4
+    },
+    {
+      "address": "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+      "description": "Word count 6 - Satoshi's address",
+      "expected": [
+        "mint",
+        "cliff",
+        "holiday",
+        "just",
+        "suave",
+        "impulse"
+      ],
+      "wordCount": 6
+    },
+    {
+      "address": "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+      "description": "Word count 8 - Satoshi's address",
+      "expected": [
+        "renew",
+        "moon",
+        "deal",
+        "valley",
+        "tissue",
+        "adventurous",
+        "reflect",
+        "physical"
+      ],
+      "wordCount": 8
+    },
+    {
+      "address": "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+      "description": "Word count 11 - Satoshi's address",
+      "expected": [
+        "rosy",
+        "inherit",
+        "young",
+        "tube",
+        "keen",
+        "broom",
+        "digital",
+        "brand",
+        "strong",
+        "proof",
+        "reform"
+      ],
+      "wordCount": 11
+    },
+    {
+      "address": "qzk7h3xH4Fmv2RqKpN8sT5jW9cY6gB1dL3mX0vQwEaUoZrJtS",
+      "description": "Context 'quantus' - salt becomes 'human-checkphrase-v2|quantus'",
+      "expected": [
+        "incredible",
+        "poppy",
+        "feasible",
+        "upside",
+        "embody"
+      ],
+      "context": "quantus"
+    },
+    {
+      "address": "0x742d35Cc6634C0532925a3b844Bc9e7595f5bE21",
+      "description": "Context 'eip155:1' - Ethereum mainnet domain separation",
+      "expected": [
+        "chat",
+        "faucet",
+        "album",
+        "fiber",
+        "jovial"
+      ],
+      "context": "eip155:1"
+    },
+    {
+      "address": "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+      "description": "Context 'bitcoin' with word count 8",
+      "expected": [
+        "govern",
+        "melt",
+        "soup",
+        "either",
+        "patient",
+        "because",
+        "portion",
+        "seven"
+      ],
+      "wordCount": 8,
+      "context": "bitcoin"
+    },
+    {
+      "address": "1TpigTHKbfoLISRABr1VjArnVgxwvqc",
+      "description": "Generated test vector #1",
+      "expected": [
+        "once",
+        "impeccable",
+        "grid",
+        "dog",
+        "venue"
       ]
     },
     {
       "address": "qzkh5esM2wleOV911xCZkwPRQeNHpCq5QnuVdYXye4JSnE2NiiUHUAKw9iEU1jjQ",
-      "description": "Generated test vector #11",
+      "description": "Generated test vector #2",
       "expected": [
-        "skill",
-        "differ",
-        "thumb",
-        "analyst",
-        "elf"
+        "piety",
+        "halcyon",
+        "boost",
+        "atom",
+        "tribe"
       ]
     },
     {
       "address": "1x9G81aSQHqNgAC72qFl41sNLjVHWGaub52Ztd26fEeVVhDIq2AnHT",
-      "description": "Generated test vector #12",
+      "description": "Generated test vector #3",
       "expected": [
-        "slab",
-        "ceiling",
-        "better",
-        "eminence",
-        "scan"
+        "toddler",
+        "remain",
+        "return",
+        "extra",
+        "few"
       ]
     },
     {
       "address": "bc1qyPx3BpdbIKaRdebuFrEHS2JpDzfOvz1dOOdTXglHilC2e",
-      "description": "Generated test vector #13",
+      "description": "Generated test vector #4",
       "expected": [
-        "common",
-        "refine",
-        "collect",
-        "proof",
-        "resource"
+        "dao",
+        "very",
+        "analyst",
+        "siege",
+        "unmatched"
       ]
     },
     {
       "address": "d9Z850kEnydx9qWCA79ISjs8JHUdKF0j7elK",
-      "description": "Generated test vector #14",
+      "description": "Generated test vector #5",
       "expected": [
-        "flexible",
-        "art",
-        "exhibit",
-        "learn",
-        "index"
+        "nurturing",
+        "october",
+        "sweet",
+        "fidelity",
+        "fertile"
       ]
     },
     {
       "address": "bc1qh3pKMzKG5mSoyPstUeC99enq522wjZRL9OaYsP6ihgIqLSmNqE4",
-      "description": "Generated test vector #15",
+      "description": "Generated test vector #6",
       "expected": [
-        "rich",
-        "code",
-        "donor",
-        "street",
-        "admire"
+        "facilitate",
+        "lean",
+        "sleep",
+        "urge",
+        "zoo"
       ]
     },
     {
       "address": "0xNZcui8kBRIg6QjcwIAcw58cwQPvI28U5o",
-      "description": "Generated test vector #16",
+      "description": "Generated test vector #7",
       "expected": [
-        "excite",
-        "gallery",
-        "idea",
-        "buzz",
-        "embrace"
+        "island",
+        "business",
+        "resilient",
+        "balcony",
+        "today"
       ]
     },
     {
       "address": "32bTu5X1YqWg21nYCsXoblu17rNy8H6h8l7qgATtL",
-      "description": "Generated test vector #17",
+      "description": "Generated test vector #8",
       "expected": [
-        "roof",
-        "keep",
-        "frisky",
-        "star",
-        "library"
+        "attract",
+        "seat",
+        "evoke",
+        "salamander",
+        "history"
       ]
     },
     {
       "address": "xJpRa5HSUPwePut0SstzyshA6P3MsHarAJOCB",
-      "description": "Generated test vector #18",
+      "description": "Generated test vector #9",
       "expected": [
-        "grateful",
-        "premier",
-        "math",
-        "twist",
-        "farm"
+        "spread",
+        "domain",
+        "point",
+        "child",
+        "glitter"
       ]
     },
     {
       "address": "bc1qD3XkfFNuYUPnmbpD0ezNmREpOaUVgAk7Gdp0CXP9K63LSFZH3UDqpNVGMr",
-      "description": "Generated test vector #19",
+      "description": "Generated test vector #10",
       "expected": [
-        "retreat",
-        "liquid",
-        "type",
-        "renew",
-        "balance"
+        "bolster",
+        "drop",
+        "savvy",
+        "deft",
+        "tunnel"
       ]
     },
     {
       "address": "1ou3ejxjnzuCdZyV6b2JD6sy3ZHTX3EqEyPXS058H4KPfA1l",
-      "description": "Generated test vector #20",
+      "description": "Generated test vector #11",
       "expected": [
-        "duty",
-        "ball",
-        "space",
-        "youth",
-        "floor"
+        "child",
+        "talk",
+        "engage",
+        "dear",
+        "wild"
       ]
     },
     {
       "address": "cosmos1uCu2r6AZDUd7ne7cbp0MoDh6CpwL7SWktJ5J4x6mKZpRsQX",
-      "description": "Generated test vector #21",
+      "description": "Generated test vector #12",
       "expected": [
-        "seamless",
-        "close",
-        "arrange",
-        "unbiased",
-        "appear"
+        "select",
+        "bullish",
+        "grand",
+        "olive",
+        "journey"
       ]
     },
     {
       "address": "0xHPeOaAEAw3CjkGOM5WCZKtp5rBUJPuEuEvqrK2IGlozIoDSBbs",
-      "description": "Generated test vector #22",
+      "description": "Generated test vector #13",
       "expected": [
-        "decorate",
-        "huge",
-        "endorse",
-        "bench",
-        "sibling"
+        "yield",
+        "near",
+        "citizen",
+        "mystery",
+        "suave"
       ]
     },
     {
       "address": "5sKDGAUuRqphlhHVlnES8GrgmolaHr8IRh1E2JDBld6DY",
-      "description": "Generated test vector #23",
+      "description": "Generated test vector #14",
       "expected": [
-        "that",
-        "fearless",
-        "celebrate",
-        "screen",
-        "amount"
-      ]
-    },
-    {
-      "address": "5eNdjIs9hVLXnGBB19sMLT6mnOjkeaBKsoRRCQ5WMO5AHO4ZektUJrhQR6FEe",
-      "description": "Generated test vector #24",
-      "expected": [
-        "stunning",
-        "brick",
-        "yield",
-        "math",
-        "safe"
-      ]
-    },
-    {
-      "address": "0xTLboP1KbVYJVkGBr9BY8DztgjzEPyVcfphV1Za1CdGMEBdqir2EbNXS",
-      "description": "Generated test vector #25",
-      "expected": [
-        "time",
-        "worth",
-        "describe",
-        "lean",
-        "silly"
-      ]
-    },
-    {
-      "address": "cosmos1If94ChZESFqZ8pIx5F21rWz",
-      "description": "Generated test vector #26",
-      "expected": [
-        "treat",
-        "unabashed",
-        "dwarf",
-        "glass",
-        "dress"
-      ]
-    },
-    {
-      "address": "YrsK9EjHvIHCtlRJoWcURYxPY8EcFK12BGCSzOjD8uQO001",
-      "description": "Generated test vector #27",
-      "expected": [
-        "often",
-        "project",
-        "cabin",
-        "aerobic",
-        "genre"
-      ]
-    },
-    {
-      "address": "5M3EHMoQrof8VRgksbudwApzQlkLxQEKoNCP3CrHe69s7QCs90",
-      "description": "Generated test vector #28",
-      "expected": [
-        "grass",
-        "indicate",
-        "motion",
-        "swarm",
-        "acquire"
-      ]
-    },
-    {
-      "address": "1xwsRbZya1W84UZ3WoXnlpUVQigMcWcwi4uzmW2wFqk46",
-      "description": "Generated test vector #29",
-      "expected": [
-        "giant",
-        "purity",
-        "remain",
-        "yard",
-        "hotcake"
-      ]
-    },
-    {
-      "address": "cosmos1XDeUnPPy0IfyqhwUqxNxPDM6uLONCROhcc9hoHyx6RHK",
-      "description": "Generated test vector #30",
-      "expected": [
-        "dauntless",
-        "breeze",
-        "elevator",
-        "devote",
-        "sober"
-      ]
-    },
-    {
-      "address": "3OZM6rQnBow8w3Ndr86ZfnN8du9WmZIKYoWWKr99HXg1iwWKaqhAhdBw",
-      "description": "Generated test vector #31",
-      "expected": [
-        "border",
-        "zeal",
-        "bright",
-        "warrior",
-        "park"
-      ]
-    },
-    {
-      "address": "1F6cW1GC7dDyQE4efLerNHu9GCLgR0OVSnBovCzfAPxj5eZffTYIKIuhvP",
-      "description": "Generated test vector #32",
-      "expected": [
-        "remember",
-        "ring",
-        "siege",
-        "loving",
-        "blameless"
-      ]
-    },
-    {
-      "address": "58LvJnOng0wVJY08YMNb5ZqlRtva1JyiN",
-      "description": "Generated test vector #33",
-      "expected": [
-        "unfazed",
-        "again",
-        "pleasant",
-        "teach",
-        "seven"
-      ]
-    },
-    {
-      "address": "0xUnAvwSWJfdjMPqPEBqUhArQEPcyLasnip",
-      "description": "Generated test vector #34",
-      "expected": [
-        "nothing",
-        "fabric",
-        "endless",
-        "patch",
-        "main"
-      ]
-    },
-    {
-      "address": "osmo1aUkxRFZXe1cb51JJRzhbuXMZ5f0pKGyt",
-      "description": "Generated test vector #35",
-      "expected": [
-        "decide",
-        "fold",
-        "finish",
-        "clutch",
-        "have"
-      ]
-    },
-    {
-      "address": "osmo1ukFhF4vTYYojmLVOkVEUVB5INM1MjeBsrdFtCdZ",
-      "description": "Generated test vector #36",
-      "expected": [
-        "amount",
-        "eager",
-        "water",
-        "gorgeous",
-        "total"
-      ]
-    },
-    {
-      "address": "1MFCIX3BYOtDjdg3vSFkpBBGjxrzuLWOefQ",
-      "description": "Generated test vector #37",
-      "expected": [
-        "grain",
-        "absent",
-        "grit",
-        "already",
-        "biology"
-      ]
-    },
-    {
-      "address": "cosmos1SO42uKiv7RyK6txXYPZTQGOAwwln6Eoie0gVZ2c",
-      "description": "Generated test vector #38",
-      "expected": [
-        "prefer",
-        "summer",
-        "morning",
-        "whale",
-        "pencil"
-      ]
-    },
-    {
-      "address": "osmo1LjlQM3ScwS8LUWoo7W4mQJBVWFzkmL2dD",
-      "description": "Generated test vector #39",
-      "expected": [
-        "aim",
-        "clean",
-        "bloom",
-        "hover",
-        "cute"
-      ]
-    },
-    {
-      "address": "osmo1SFhfjBFZf4Y25zyxxfntgSujc4DZVDM",
-      "description": "Generated test vector #40",
-      "expected": [
-        "soothe",
-        "myself",
-        "lyrics",
-        "fidelity",
-        "capital"
-      ]
-    },
-    {
-      "address": "1pZITGgrscAXCg4KbFpiAMozPf8eGF9",
-      "description": "Generated test vector #41",
-      "expected": [
-        "fortune",
-        "primary",
-        "always",
-        "update",
-        "stamp"
-      ]
-    },
-    {
-      "address": "yDN8pbWvTMVTucHYkWCRNYdWCscmc5F",
-      "description": "Generated test vector #42",
-      "expected": [
-        "stroll",
-        "reflect",
-        "fruit",
-        "classy",
-        "proud"
-      ]
-    },
-    {
-      "address": "pUlwW1uhw3U3x8EE5GXTeLYHteOtLAQvc1v9r86eNwXQ7iLWceWwxJLQ6xVJ",
-      "description": "Generated test vector #43",
-      "expected": [
-        "quarter",
-        "pelican",
-        "regal",
-        "mesh",
-        "salon"
-      ]
-    },
-    {
-      "address": "yOphTExIqqB9r4Eh0C3BfQ0tveH30S5NXFhmiXbIwXILft9SGVZe8",
-      "description": "Generated test vector #44",
-      "expected": [
-        "dazzling",
-        "viable",
-        "calm",
-        "celebrate",
-        "layer"
-      ]
-    },
-    {
-      "address": "1CGhZIKViF1ZGsk5n6Grem7rMMfNKKkM3u5c1f6VqnJMb3HNspYzCQjzCv",
-      "description": "Generated test vector #45",
-      "expected": [
-        "pilot",
-        "symbol",
-        "bright",
-        "humble",
-        "domain"
-      ]
-    },
-    {
-      "address": "31t9vyVFgohBid61z73Y5Slj9C2EfyCoKdrL0PragiqwzcdIwr",
-      "description": "Generated test vector #46",
-      "expected": [
-        "ceiling",
-        "area",
-        "rise",
-        "ready",
-        "shine"
-      ]
-    },
-    {
-      "address": "5BIZMLhfx9IwiLyccSXGj3i5tyM0KFFEIDbugzt32NLqO8JodDGSWxYpJRlBzz",
-      "description": "Generated test vector #47",
-      "expected": [
-        "biology",
-        "half",
-        "orient",
-        "bulk",
-        "medal"
-      ]
-    },
-    {
-      "address": "bc1qFLD0TRGI9Dx7CHHP1QXqE7rs68VRQEDI5SrJH3yvVjc7e5OUnZqI",
-      "description": "Generated test vector #48",
-      "expected": [
-        "joyous",
-        "spin",
-        "rapport",
-        "aunt",
-        "tissue"
-      ]
-    },
-    {
-      "address": "cosmos1gTod4noguDQi78jO2DOUrrdVOoT0c5z",
-      "description": "Generated test vector #49",
-      "expected": [
-        "suit",
-        "landmark",
-        "wins",
-        "astute",
-        "harmony"
-      ]
-    },
-    {
-      "address": "39yE6752aJg8r9HE60DlgkCplTXJUk13",
-      "description": "Generated test vector #50",
-      "expected": [
-        "wrist",
-        "express",
-        "screen",
-        "year",
-        "knee"
-      ]
-    },
-    {
-      "address": "5uyf8D6axBquKJqwoPCjQ53VQN6wn7DC9xR4UXZVQKWGGw4gZ3mHk0BQSE3Bdi",
-      "description": "Generated test vector #51",
-      "expected": [
-        "fix",
-        "solid",
-        "vivid",
-        "maximum",
-        "scan"
-      ]
-    },
-    {
-      "address": "5IIPtbpaneARHd39DrliNT7x3B4xe72i1h9yh8ZU8CSAxoCjl2VbOM63oeK",
-      "description": "Generated test vector #52",
-      "expected": [
-        "public",
-        "lavender",
-        "sleep",
-        "hen",
-        "view"
-      ]
-    },
-    {
-      "address": "qzkpcBHUWi9o4JJVYo29GzrIKTkQIcvNx",
-      "description": "Generated test vector #53",
-      "expected": [
-        "home",
-        "window",
-        "clap",
-        "twist",
-        "join"
-      ]
-    },
-    {
-      "address": "RzslHon1iCdzzGypueBxHZdxLceXKPnm4s4nlTUU4RRyotrCOt",
-      "description": "Generated test vector #54",
-      "expected": [
-        "rich",
-        "receive",
-        "cipher",
-        "auto",
-        "know"
-      ]
-    },
-    {
-      "address": "osmo12CXSVtmtc1TbIKSsmoJpI6uVESTCTviHl397G0eYdaiNejnCdN54OaGzb",
-      "description": "Generated test vector #55",
-      "expected": [
-        "verb",
-        "doctor",
-        "unveil",
-        "vivid",
-        "mass"
-      ]
-    },
-    {
-      "address": "cosmos18bYPX4gfjlGYqyxzJ9oQ0O1VfxIdakEAWJ1fGcn13Dce53Ic5t7KUSyek",
-      "description": "Generated test vector #56",
-      "expected": [
-        "meadow",
-        "sample",
-        "property",
-        "glee",
-        "badge"
-      ]
-    },
-    {
-      "address": "bc1qPHxTXQeUvgoeLMK8uNWBoIxlKxVspeqxWjywf6BVgfAIFgfILW",
-      "description": "Generated test vector #57",
-      "expected": [
-        "inspire",
-        "nice",
-        "shoe",
-        "giant",
-        "knee"
-      ]
-    },
-    {
-      "address": "5syf348JkxisEdAAEeppMKmgs6uMXu",
-      "description": "Generated test vector #58",
-      "expected": [
-        "unique",
-        "item",
-        "keypair",
-        "wine",
-        "bolster"
-      ]
-    },
-    {
-      "address": "osmo1Y18it6mt78sREJpxYyhIKHQI7CRBsQYXzENpOSWe9DyF5QHXw3HN",
-      "description": "Generated test vector #59",
-      "expected": [
-        "frequent",
-        "intuitive",
-        "crucial",
-        "protect",
-        "duty"
-      ]
-    },
-    {
-      "address": "1VOwOc8QyU7AaqFGJJByVKFvbgz7h6itCmDD",
-      "description": "Generated test vector #60",
-      "expected": [
-        "valve",
-        "mesh",
-        "anchor",
-        "venerate",
-        "crop"
-      ]
-    },
-    {
-      "address": "qzktsYh0OPk9pkjI7ozlNAbMmKyRmUYdg2luCq1GNLLKv0MYRsMfihslQF",
-      "description": "Generated test vector #61",
-      "expected": [
-        "same",
-        "purse",
-        "silent",
-        "eight",
-        "midnight"
-      ]
-    },
-    {
-      "address": "5JAEH45kkrl0M17EmxIOzESBkJXncnrWJVEFJq",
-      "description": "Generated test vector #62",
-      "expected": [
-        "distance",
-        "coil",
-        "medal",
-        "exist",
-        "float"
-      ]
-    },
-    {
-      "address": "HUVBnATOp2bq1f1hYnTQ1LAMWYXJHLk8sJ7F3YiUzdrORijtp0yiN",
-      "description": "Generated test vector #63",
-      "expected": [
-        "ripple",
-        "lion",
-        "viable",
-        "enlightened",
-        "trend"
-      ]
-    },
-    {
-      "address": "5CN2fFr6w6uaVTTCPwdHnAnqZuJJEvQdgWCh1Ba7mQiOj5qOpx4kys",
-      "description": "Generated test vector #64",
-      "expected": [
-        "wide",
-        "armor",
-        "jacket",
-        "chief",
-        "arrive"
-      ]
-    },
-    {
-      "address": "bc1qORaDioQaRY9AiexTgt2iVUi9iGaOBSMjzQ1fgUKx7tirfILLWQ0Os",
-      "description": "Generated test vector #65",
-      "expected": [
-        "reach",
-        "tackle",
-        "ergonomic",
-        "cute",
-        "sophisticated"
-      ]
-    },
-    {
-      "address": "lyOWXoxoNe3awtx0AHkD9eKan56yrSVAyNHjfe58juKVONtB7op5hLdPOkaiaE",
-      "description": "Generated test vector #66",
-      "expected": [
-        "code",
-        "magic",
-        "wealth",
-        "detect",
-        "sail"
-      ]
-    },
-    {
-      "address": "osmo1GYqxU2Th3uAGq8MEFd1kjV3PhTa1acw5l7cXSOnp4tZJhPdnFcy21VtfCw",
-      "description": "Generated test vector #67",
-      "expected": [
-        "oval",
-        "real",
-        "latin",
-        "kiss",
+        "mechanic",
+        "select",
+        "island",
+        "what",
         "connect"
       ]
     },
     {
-      "address": "cosmos1Tpw89WTHXj5bHNQauVxTtm8A78irco0z3CUKFNyKdP",
-      "description": "Generated test vector #68",
+      "address": "5eNdjIs9hVLXnGBB19sMLT6mnOjkeaBKsoRRCQ5WMO5AHO4ZektUJrhQR6FEe",
+      "description": "Generated test vector #15",
       "expected": [
-        "purity",
-        "shrimp",
-        "cheese",
-        "blossom",
-        "check"
+        "night",
+        "seven",
+        "bounty",
+        "mightily",
+        "rapport"
+      ]
+    },
+    {
+      "address": "0xTLboP1KbVYJVkGBr9BY8DztgjzEPyVcfphV1Za1CdGMEBdqir2EbNXS",
+      "description": "Generated test vector #16",
+      "expected": [
+        "team",
+        "donor",
+        "enable",
+        "feature",
+        "orchard"
+      ]
+    },
+    {
+      "address": "cosmos1If94ChZESFqZ8pIx5F21rWz",
+      "description": "Generated test vector #17",
+      "expected": [
+        "woman",
+        "enact",
+        "zeal",
+        "text",
+        "object"
+      ]
+    },
+    {
+      "address": "YrsK9EjHvIHCtlRJoWcURYxPY8EcFK12BGCSzOjD8uQO001",
+      "description": "Generated test vector #18",
+      "expected": [
+        "robot",
+        "donor",
+        "fame",
+        "half",
+        "wow"
+      ]
+    },
+    {
+      "address": "5M3EHMoQrof8VRgksbudwApzQlkLxQEKoNCP3CrHe69s7QCs90",
+      "description": "Generated test vector #19",
+      "expected": [
+        "wash",
+        "diligent",
+        "display",
+        "envelope",
+        "hash"
+      ]
+    },
+    {
+      "address": "1xwsRbZya1W84UZ3WoXnlpUVQigMcWcwi4uzmW2wFqk46",
+      "description": "Generated test vector #20",
+      "expected": [
+        "style",
+        "blur",
+        "board",
+        "pact",
+        "pardon"
+      ]
+    },
+    {
+      "address": "cosmos1XDeUnPPy0IfyqhwUqxNxPDM6uLONCROhcc9hoHyx6RHK",
+      "description": "Generated test vector #21",
+      "expected": [
+        "local",
+        "there",
+        "venerate",
+        "adorable",
+        "buoyant"
+      ]
+    },
+    {
+      "address": "3OZM6rQnBow8w3Ndr86ZfnN8du9WmZIKYoWWKr99HXg1iwWKaqhAhdBw",
+      "description": "Generated test vector #22",
+      "expected": [
+        "depend",
+        "leaf",
+        "before",
+        "ensure",
+        "tone"
+      ]
+    },
+    {
+      "address": "1F6cW1GC7dDyQE4efLerNHu9GCLgR0OVSnBovCzfAPxj5eZffTYIKIuhvP",
+      "description": "Generated test vector #23",
+      "expected": [
+        "unveil",
+        "upbeat",
+        "wieldy",
+        "hidden",
+        "cloud"
+      ]
+    },
+    {
+      "address": "58LvJnOng0wVJY08YMNb5ZqlRtva1JyiN",
+      "description": "Generated test vector #24",
+      "expected": [
+        "exultant",
+        "influential",
+        "wet",
+        "syrup",
+        "host"
+      ]
+    },
+    {
+      "address": "0xUnAvwSWJfdjMPqPEBqUhArQEPcyLasnip",
+      "description": "Generated test vector #25",
+      "expected": [
+        "twenty",
+        "slot",
+        "about",
+        "pizza",
+        "bundle"
+      ]
+    },
+    {
+      "address": "osmo1aUkxRFZXe1cb51JJRzhbuXMZ5f0pKGyt",
+      "description": "Generated test vector #26",
+      "expected": [
+        "perfect",
+        "stable",
+        "analyst",
+        "resemble",
+        "hello"
+      ]
+    },
+    {
+      "address": "osmo1ukFhF4vTYYojmLVOkVEUVB5INM1MjeBsrdFtCdZ",
+      "description": "Generated test vector #27",
+      "expected": [
+        "prowess",
+        "notable",
+        "amused",
+        "overjoyed",
+        "loving"
+      ]
+    },
+    {
+      "address": "1MFCIX3BYOtDjdg3vSFkpBBGjxrzuLWOefQ",
+      "description": "Generated test vector #28",
+      "expected": [
+        "spray",
+        "snack",
+        "undamaged",
+        "efficient",
+        "loyal"
+      ]
+    },
+    {
+      "address": "cosmos1SO42uKiv7RyK6txXYPZTQGOAwwln6Eoie0gVZ2c",
+      "description": "Generated test vector #29",
+      "expected": [
+        "cliff",
+        "tonight",
+        "subway",
+        "burger",
+        "fruit"
+      ]
+    },
+    {
+      "address": "osmo1LjlQM3ScwS8LUWoo7W4mQJBVWFzkmL2dD",
+      "description": "Generated test vector #30",
+      "expected": [
+        "word",
+        "power",
+        "yummy",
+        "loyal",
+        "orchard"
+      ]
+    },
+    {
+      "address": "osmo1SFhfjBFZf4Y25zyxxfntgSujc4DZVDM",
+      "description": "Generated test vector #31",
+      "expected": [
+        "ritual",
+        "terrific",
+        "fox",
+        "bundle",
+        "embark"
+      ]
+    },
+    {
+      "address": "1pZITGgrscAXCg4KbFpiAMozPf8eGF9",
+      "description": "Generated test vector #32",
+      "expected": [
+        "jaguar",
+        "fossil",
+        "lemur",
+        "face",
+        "churn"
+      ]
+    },
+    {
+      "address": "yDN8pbWvTMVTucHYkWCRNYdWCscmc5F",
+      "description": "Generated test vector #33",
+      "expected": [
+        "calm",
+        "select",
+        "draw",
+        "swing",
+        "hooray"
+      ]
+    },
+    {
+      "address": "pUlwW1uhw3U3x8EE5GXTeLYHteOtLAQvc1v9r86eNwXQ7iLWceWwxJLQ6xVJ",
+      "description": "Generated test vector #34",
+      "expected": [
+        "slab",
+        "fork",
+        "unwavering",
+        "story",
+        "weekend"
+      ]
+    },
+    {
+      "address": "yOphTExIqqB9r4Eh0C3BfQ0tveH30S5NXFhmiXbIwXILft9SGVZe8",
+      "description": "Generated test vector #35",
+      "expected": [
+        "crush",
+        "above",
+        "search",
+        "urban",
+        "palace"
+      ]
+    },
+    {
+      "address": "1CGhZIKViF1ZGsk5n6Grem7rMMfNKKkM3u5c1f6VqnJMb3HNspYzCQjzCv",
+      "description": "Generated test vector #36",
+      "expected": [
+        "joy",
+        "flying",
+        "shell",
+        "find",
+        "hotcake"
+      ]
+    },
+    {
+      "address": "31t9vyVFgohBid61z73Y5Slj9C2EfyCoKdrL0PragiqwzcdIwr",
+      "description": "Generated test vector #37",
+      "expected": [
+        "taxi",
+        "pink",
+        "doll",
+        "superb",
+        "dragon"
+      ]
+    },
+    {
+      "address": "5BIZMLhfx9IwiLyccSXGj3i5tyM0KFFEIDbugzt32NLqO8JodDGSWxYpJRlBzz",
+      "description": "Generated test vector #38",
+      "expected": [
+        "security",
+        "stable",
+        "encrypt",
+        "session",
+        "nice"
+      ]
+    },
+    {
+      "address": "bc1qFLD0TRGI9Dx7CHHP1QXqE7rs68VRQEDI5SrJH3yvVjc7e5OUnZqI",
+      "description": "Generated test vector #39",
+      "expected": [
+        "coyote",
+        "reason",
+        "glide",
+        "motor",
+        "side"
+      ]
+    },
+    {
+      "address": "cosmos1gTod4noguDQi78jO2DOUrrdVOoT0c5z",
+      "description": "Generated test vector #40",
+      "expected": [
+        "nourish",
+        "eager",
+        "lion",
+        "ecstatic",
+        "paper"
+      ]
+    },
+    {
+      "address": "39yE6752aJg8r9HE60DlgkCplTXJUk13",
+      "description": "Generated test vector #41",
+      "expected": [
+        "spoil",
+        "toward",
+        "basic",
+        "hen",
+        "facilitate"
+      ]
+    },
+    {
+      "address": "5uyf8D6axBquKJqwoPCjQ53VQN6wn7DC9xR4UXZVQKWGGw4gZ3mHk0BQSE3Bdi",
+      "description": "Generated test vector #42",
+      "expected": [
+        "invite",
+        "often",
+        "piety",
+        "collect",
+        "copper"
+      ]
+    },
+    {
+      "address": "5IIPtbpaneARHd39DrliNT7x3B4xe72i1h9yh8ZU8CSAxoCjl2VbOM63oeK",
+      "description": "Generated test vector #43",
+      "expected": [
+        "border",
+        "board",
+        "mist",
+        "way",
+        "video"
+      ]
+    },
+    {
+      "address": "qzkpcBHUWi9o4JJVYo29GzrIKTkQIcvNx",
+      "description": "Generated test vector #44",
+      "expected": [
+        "minute",
+        "nut",
+        "boy",
+        "icon",
+        "unquestionable"
+      ]
+    },
+    {
+      "address": "RzslHon1iCdzzGypueBxHZdxLceXKPnm4s4nlTUU4RRyotrCOt",
+      "description": "Generated test vector #45",
+      "expected": [
+        "will",
+        "color",
+        "mimic",
+        "legend",
+        "kangaroo"
+      ]
+    },
+    {
+      "address": "osmo12CXSVtmtc1TbIKSsmoJpI6uVESTCTviHl397G0eYdaiNejnCdN54OaGzb",
+      "description": "Generated test vector #46",
+      "expected": [
+        "sparkle",
+        "exchange",
+        "caution",
+        "boring",
+        "wealth"
+      ]
+    },
+    {
+      "address": "cosmos18bYPX4gfjlGYqyxzJ9oQ0O1VfxIdakEAWJ1fGcn13Dce53Ic5t7KUSyek",
+      "description": "Generated test vector #47",
+      "expected": [
+        "chalk",
+        "lake",
+        "piano",
+        "shop",
+        "bicycle"
+      ]
+    },
+    {
+      "address": "bc1qPHxTXQeUvgoeLMK8uNWBoIxlKxVspeqxWjywf6BVgfAIFgfILW",
+      "description": "Generated test vector #48",
+      "expected": [
+        "coin",
+        "cinnamon",
+        "monitor",
+        "dress",
+        "similar"
+      ]
+    },
+    {
+      "address": "5syf348JkxisEdAAEeppMKmgs6uMXu",
+      "description": "Generated test vector #49",
+      "expected": [
+        "found",
+        "adventurous",
+        "until",
+        "happy",
+        "huge"
+      ]
+    },
+    {
+      "address": "osmo1Y18it6mt78sREJpxYyhIKHQI7CRBsQYXzENpOSWe9DyF5QHXw3HN",
+      "description": "Generated test vector #50",
+      "expected": [
+        "orchard",
+        "suffice",
+        "magic",
+        "choice",
+        "leader"
+      ]
+    },
+    {
+      "address": "1VOwOc8QyU7AaqFGJJByVKFvbgz7h6itCmDD",
+      "description": "Generated test vector #51",
+      "expected": [
+        "exalt",
+        "unique",
+        "valid",
+        "galaxy",
+        "elan"
+      ]
+    },
+    {
+      "address": "qzktsYh0OPk9pkjI7ozlNAbMmKyRmUYdg2luCq1GNLLKv0MYRsMfihslQF",
+      "description": "Generated test vector #52",
+      "expected": [
+        "midnight",
+        "maximum",
+        "month",
+        "believe",
+        "outreach"
+      ]
+    },
+    {
+      "address": "5JAEH45kkrl0M17EmxIOzESBkJXncnrWJVEFJq",
+      "description": "Generated test vector #53",
+      "expected": [
+        "liquid",
+        "savvy",
+        "neck",
+        "choice",
+        "major"
+      ]
+    },
+    {
+      "address": "HUVBnATOp2bq1f1hYnTQ1LAMWYXJHLk8sJ7F3YiUzdrORijtp0yiN",
+      "description": "Generated test vector #54",
+      "expected": [
+        "pattern",
+        "hottest",
+        "laptop",
+        "daughter",
+        "screen"
+      ]
+    },
+    {
+      "address": "5CN2fFr6w6uaVTTCPwdHnAnqZuJJEvQdgWCh1Ba7mQiOj5qOpx4kys",
+      "description": "Generated test vector #55",
+      "expected": [
+        "gather",
+        "kick",
+        "employ",
+        "privilege",
+        "profit"
+      ]
+    },
+    {
+      "address": "bc1qORaDioQaRY9AiexTgt2iVUi9iGaOBSMjzQ1fgUKx7tirfILLWQ0Os",
+      "description": "Generated test vector #56",
+      "expected": [
+        "account",
+        "lucky",
+        "raven",
+        "hope",
+        "tag"
+      ]
+    },
+    {
+      "address": "lyOWXoxoNe3awtx0AHkD9eKan56yrSVAyNHjfe58juKVONtB7op5hLdPOkaiaE",
+      "description": "Generated test vector #57",
+      "expected": [
+        "fond",
+        "also",
+        "vital",
+        "math",
+        "extend"
+      ]
+    },
+    {
+      "address": "osmo1GYqxU2Th3uAGq8MEFd1kjV3PhTa1acw5l7cXSOnp4tZJhPdnFcy21VtfCw",
+      "description": "Generated test vector #58",
+      "expected": [
+        "tube",
+        "squirrel",
+        "large",
+        "terrific",
+        "lens"
+      ]
+    },
+    {
+      "address": "cosmos1Tpw89WTHXj5bHNQauVxTtm8A78irco0z3CUKFNyKdP",
+      "description": "Generated test vector #59",
+      "expected": [
+        "opera",
+        "tiny",
+        "level",
+        "truth",
+        "verify"
       ]
     },
     {
       "address": "3s05yZuCo6iVggBthwVCC0fYsRLn1jS8ydsYk70IIfgXh",
-      "description": "Generated test vector #69",
+      "description": "Generated test vector #60",
       "expected": [
-        "eager",
-        "panel",
-        "foster",
-        "vacuum",
-        "mirror"
+        "aim",
+        "cool",
+        "question",
+        "joyful",
+        "ovation"
       ]
     },
     {
       "address": "0xiZxNNKqYbd3Bh4ZucCkJYybQknlr2cMpszIdrim2GN",
-      "description": "Generated test vector #70",
+      "description": "Generated test vector #61",
       "expected": [
-        "volcano",
-        "orange",
-        "permissible",
-        "match",
-        "dextrous"
+        "copy",
+        "object",
+        "ardor",
+        "tough",
+        "mist"
       ]
     },
     {
       "address": "9WwHE4Fyltn3Wd9GV98gOqY4d9n0Xv0",
-      "description": "Generated test vector #71",
+      "description": "Generated test vector #62",
       "expected": [
-        "lily",
-        "ripple",
-        "brief",
-        "round",
-        "feasible"
+        "want",
+        "acquire",
+        "broccoli",
+        "pulse",
+        "marriage"
       ]
     },
     {
       "address": "3otTwKRvJi6ZY8HkcdLbDuMXvlX1djRigGweRPKuu",
-      "description": "Generated test vector #72",
+      "description": "Generated test vector #63",
       "expected": [
-        "fog",
-        "light",
-        "aware",
-        "museum",
-        "sea"
+        "stunning",
+        "salmon",
+        "trade",
+        "spawn",
+        "rural"
       ]
     },
     {
       "address": "3X7Ok8R5WnKktQhT66y97cL57nJ6iUo8k2fRN2BqpepgaxT82ExHgD1OQ",
-      "description": "Generated test vector #73",
+      "description": "Generated test vector #64",
       "expected": [
-        "math",
-        "joyous",
-        "connect",
-        "sword",
-        "doctor"
+        "switch",
+        "enable",
+        "shiver",
+        "lesson",
+        "cushion"
       ]
     },
     {
       "address": "3e0st7ekxTH3fKMDb6k3jgmlRSTqrodJ0jwAsPLmbksf0tyEOfHl2wBqCo",
-      "description": "Generated test vector #74",
+      "description": "Generated test vector #65",
       "expected": [
-        "mass",
-        "prudence",
-        "sibling",
-        "cinnamon",
-        "network"
+        "chief",
+        "dwarf",
+        "coil",
+        "sweet",
+        "banner"
       ]
     },
     {
       "address": "cosmos1jRfPYzUodyG7Q6Josy0cJGJ8j6",
-      "description": "Generated test vector #75",
+      "description": "Generated test vector #66",
       "expected": [
-        "pray",
-        "cricket",
-        "scissors",
-        "size",
+        "there",
+        "donor",
+        "like",
+        "clutch",
         "shuffle"
       ]
     },
     {
       "address": "qzk6knlceQmYjKtTYfII1G4aRKWgjJK7ggWW122qO",
-      "description": "Generated test vector #76",
+      "description": "Generated test vector #67",
       "expected": [
-        "job",
-        "exonerate",
-        "cheese",
-        "dash",
-        "corn"
+        "steadfast",
+        "shine",
+        "before",
+        "public",
+        "slush"
       ]
     },
     {
       "address": "qzkkyMQyy2QdDqxuXt01Q8osUVtTLfB4",
-      "description": "Generated test vector #77",
-      "expected": [
-        "sand",
-        "gym",
-        "spatial",
-        "clean",
-        "intuitive"
-      ]
-    },
-    {
-      "address": "5V1YFjtFi02blZZpC4RqZFNhbxKl1Kvk3UQrxkJ71OQqzbWVa4OLapXs7NAxv",
-      "description": "Generated test vector #78",
-      "expected": [
-        "pilot",
-        "zest",
-        "vapor",
-        "lucid",
-        "post"
-      ]
-    },
-    {
-      "address": "cosmos1CPZygFP0xOLsgd9N1qS3sjV3XXLOQSO9qzyc",
-      "description": "Generated test vector #79",
-      "expected": [
-        "furnace",
-        "swallow",
-        "fortune",
-        "engrossing",
-        "lizard"
-      ]
-    },
-    {
-      "address": "bc1qTnHW4PF002lghqYVlQufwUtWuqs0D1K6e3F1xsd0imzJ4Ct",
-      "description": "Generated test vector #80",
-      "expected": [
-        "ribbon",
-        "galaxy",
-        "that",
-        "peerless",
-        "mimic"
-      ]
-    },
-    {
-      "address": "3ENkNaqVkVEVfMNz7xcmxatZlPMpQvhxKkZ",
-      "description": "Generated test vector #81",
-      "expected": [
-        "evoke",
-        "learn",
-        "beach",
-        "gather",
-        "kingdom"
-      ]
-    },
-    {
-      "address": "cosmos1CGGAQi9EUk4Ybn9nbFhSXxNVMKcgZchBhpRmQaAgG",
-      "description": "Generated test vector #82",
-      "expected": [
-        "year",
-        "cradle",
-        "history",
-        "position",
-        "baby"
-      ]
-    },
-    {
-      "address": "3ZgShhgmmqGmRscEm5uaP4ZPjfFSgpo9sCgkcsXtTfVc0PkwBM2fYly7",
-      "description": "Generated test vector #83",
-      "expected": [
-        "rabbit",
-        "harvest",
-        "guide",
-        "smile",
-        "employ"
-      ]
-    },
-    {
-      "address": "cosmos1QDA2kiT80g4DJBLWL12T3DE3BdOa1GUSn72GQMATDPNjZ3M",
-      "description": "Generated test vector #84",
-      "expected": [
-        "delectable",
-        "enchant",
-        "impact",
-        "walnut",
-        "boost"
-      ]
-    },
-    {
-      "address": "0xFDEkUturFIxYeBJfEt8UbzcIZX7N3IOCvZY0uV",
-      "description": "Generated test vector #85",
-      "expected": [
-        "idea",
-        "embody",
-        "core",
-        "stock",
-        "boring"
-      ]
-    },
-    {
-      "address": "qzkShVnvZ7sGRckiSSgLl5yCWSgz5ZKVBO7iEGd50DF5kJThyL2Fx",
-      "description": "Generated test vector #86",
-      "expected": [
-        "swim",
-        "explain",
-        "mountain",
-        "trumpet",
-        "upheld"
-      ]
-    },
-    {
-      "address": "bc1qyvsXiL2F0HtTInnSQ5iS8lHNSVIK6SP3H2AagxddqW8",
-      "description": "Generated test vector #87",
-      "expected": [
-        "lavish",
-        "significant",
-        "broccoli",
-        "refresh",
-        "hydra"
-      ]
-    },
-    {
-      "address": "cosmos10QsUcYg1T1UIoWXrP5y78tIapMW1Z4RO",
-      "description": "Generated test vector #88",
-      "expected": [
-        "dad",
-        "truth",
-        "purity",
-        "impeccable",
-        "bar"
-      ]
-    },
-    {
-      "address": "W7slQlkFxAIiKpuSjjud5MPEJwWtnleFzHfnnuwnUG",
-      "description": "Generated test vector #89",
-      "expected": [
-        "summer",
-        "act",
-        "lizard",
-        "orient",
-        "aunt"
-      ]
-    },
-    {
-      "address": "hvoN4pc2xXhpSbGVFFEsOtff8VHMnN",
-      "description": "Generated test vector #90",
-      "expected": [
-        "star",
-        "assist",
-        "abundance",
-        "elephant",
-        "news"
-      ]
-    },
-    {
-      "address": "bc1qZmZ2TAYeQbScelpeY4zBztyhaSdUc0wFrQLr5xYbjnUX0sNs271O7",
-      "description": "Generated test vector #91",
-      "expected": [
-        "pool",
-        "unbound",
-        "fertile",
-        "laud",
-        "need"
-      ]
-    },
-    {
-      "address": "0xhaKH6sU4vzOFjnZmlX0059CIsegSEuhOgM3tB",
-      "description": "Generated test vector #92",
-      "expected": [
-        "sound",
-        "cool",
-        "hottest",
-        "torch",
-        "atom"
-      ]
-    },
-    {
-      "address": "cosmos1JwtAapnTB0iT2CwsIkL01iHq2eebFbKz",
-      "description": "Generated test vector #93",
-      "expected": [
-        "tolerant",
-        "lawn",
-        "shift",
-        "dove",
-        "road"
-      ]
-    },
-    {
-      "address": "bc1qIH9DWwnVTsCFyFP0YMkFBl6O7TDw",
-      "description": "Generated test vector #94",
-      "expected": [
-        "cool",
-        "move",
-        "lush",
-        "theme",
-        "write"
-      ]
-    },
-    {
-      "address": "bc1qoqoPGXy42cOg8NqTJJxxK3ep8nzYvX3a2BoFrjjLYOzuhPDKOzphKiF3j",
-      "description": "Generated test vector #95",
-      "expected": [
-        "absorb",
-        "number",
-        "zeal",
-        "tiny",
-        "step"
-      ]
-    },
-    {
-      "address": "35Gz8N2TY6nLDDnziKVMFkQ5KexibG4QZLl3L2GUfO3Ha6",
-      "description": "Generated test vector #96",
-      "expected": [
-        "hash",
-        "tackle",
-        "join",
-        "scissors",
-        "digital"
-      ]
-    },
-    {
-      "address": "5A2RA6DVvX4ZJApV4fLHpaUaGGxmXzgAKqHJL9ymIIlID9JWyi1hoW6gFWXMQdy",
-      "description": "Generated test vector #97",
-      "expected": [
-        "session",
-        "lawn",
-        "dial",
-        "gym",
-        "angel"
-      ]
-    },
-    {
-      "address": "0xZDLfqwLS5yOr7dVkEa05GmWFRMPwO8fry",
-      "description": "Generated test vector #98",
-      "expected": [
-        "lumber",
-        "asset",
-        "festival",
-        "author",
-        "rectified"
-      ]
-    },
-    {
-      "address": "5KGTefrZ4v7rLm5Jqzges6X72YJR7IVU7CCKbheN9Pot7GaZpfPYe5D",
-      "description": "Generated test vector #99",
-      "expected": [
-        "annual",
-        "task",
-        "pluck",
-        "endorse",
-        "toy"
-      ]
-    },
-    {
-      "address": "osmo13q6Q4EmT2mmpMjg5PPMVHcDME931E94rnJdXDH",
-      "description": "Generated test vector #100",
-      "expected": [
-        "sustain",
-        "enable",
-        "dose",
-        "domain",
-        "pink"
-      ]
-    },
-    {
-      "address": "yQk8RCQanKuLqIoDMwEnRx0rliJogqoAxj7jXkE90GSWsIJyQdYD",
-      "description": "Generated test vector #101",
-      "expected": [
-        "people",
-        "that",
-        "sibling",
-        "night",
-        "identify"
-      ]
-    },
-    {
-      "address": "1UqwIYvzvQLJOH8ruFWBeMC71N5ALz4evtOSLy3W6UGBk0hopUUnyf6DdV",
-      "description": "Generated test vector #102",
-      "expected": [
-        "model",
-        "divine",
-        "dish",
-        "mammal",
-        "cable"
-      ]
-    },
-    {
-      "address": "gMf5yoTBhGkcw41C15Ii6HKCU2ANH4Doftz",
-      "description": "Generated test vector #103",
-      "expected": [
-        "review",
-        "illuminate",
-        "attend",
-        "answer",
-        "sound"
-      ]
-    },
-    {
-      "address": "3aGVirHQEUsVXLXHl2BpSOZneMGXMRqOGqleigCCREtj8b8rh",
-      "description": "Generated test vector #104",
-      "expected": [
-        "vigor",
-        "soup",
-        "bargain",
-        "leader",
-        "inch"
-      ]
-    },
-    {
-      "address": "qzkojEvtX9CXu07dWeDl0YZhVpVBTc",
-      "description": "Generated test vector #105",
-      "expected": [
-        "knock",
-        "approve",
-        "dust",
-        "vacuum",
-        "mist"
-      ]
-    },
-    {
-      "address": "qzkG8DQtuNc6GpNm31nhNukrhWacWDKxfjfM",
-      "description": "Generated test vector #106",
-      "expected": [
-        "seek",
-        "order",
-        "match",
-        "custom",
-        "come"
-      ]
-    },
-    {
-      "address": "0xwjHgEtINv3TbxSpcRIHEJHuD1L1jGBY",
-      "description": "Generated test vector #107",
-      "expected": [
-        "purpose",
-        "elated",
-        "castle",
-        "actual",
-        "reclaim"
-      ]
-    },
-    {
-      "address": "CWFT2MwMtd7YlQVjrztfOc6lbglbNyEMKdnSa5O5ZDNwU3YXdMGTZ",
-      "description": "Generated test vector #108",
-      "expected": [
-        "hidden",
-        "yard",
-        "buzz",
-        "eloquence",
-        "giant"
-      ]
-    },
-    {
-      "address": "17gSGlGpMlUzgNwCP2klyuj9Bvt9uxVATLInV5p7ByT",
-      "description": "Generated test vector #109",
-      "expected": [
-        "foolproof",
-        "globe",
-        "approve",
-        "urge",
-        "radio"
-      ]
-    },
-    {
-      "address": "cosmos1G9ssn1bYQrII5jcwiwKoYfy4",
-      "description": "Generated test vector #110",
-      "expected": [
-        "loop",
-        "sweet",
-        "savvy",
-        "broccoli",
-        "resource"
-      ]
-    },
-    {
-      "address": "1XkZQJ4KsTJedVvYz11oOLaWxscHjFndTyBKFnryifJdyfFVii",
-      "description": "Generated test vector #111",
-      "expected": [
-        "impulse",
-        "lenient",
-        "slab",
-        "twin",
-        "vigilant"
-      ]
-    },
-    {
-      "address": "EOmMTpeWu5fPAvtKbs9M9BjcYmxU0gd651YaRgBbmH",
-      "description": "Generated test vector #112",
-      "expected": [
-        "return",
-        "scale",
-        "burden",
-        "adorable",
-        "tiny"
-      ]
-    },
-    {
-      "address": "bc1qGqDTiRbKPckrWMdOayq0O1b1Oox8gt1GlFC5bpGuyjvvMo8FYM23YbIrj3Of",
-      "description": "Generated test vector #113",
-      "expected": [
-        "half",
-        "holiday",
-        "success",
-        "impressed",
-        "orange"
-      ]
-    },
-    {
-      "address": "57LMooj84uHmiHX1tRGi98i54tI6ht2TV2zzB535qWglVLqJooQwQDFLSx0Eilb",
-      "description": "Generated test vector #114",
-      "expected": [
-        "aid",
-        "amiable",
-        "honor",
-        "stand",
-        "fuel"
-      ]
-    },
-    {
-      "address": "0x6nPmmk7BMQ13AWLZSy6JHNRcgC22pH8cyV7lB2Vrks4Q4",
-      "description": "Generated test vector #115",
-      "expected": [
-        "aspect",
-        "exemplar",
-        "invest",
-        "match",
-        "surprise"
-      ]
-    },
-    {
-      "address": "qzkfFlK3HyubC332fuOSkTfRNfRT8LjIcku21kiVdtT7rl37aVaEEYLEnO",
-      "description": "Generated test vector #116",
-      "expected": [
-        "knee",
-        "canyon",
-        "matrix",
-        "formidable",
-        "volcano"
-      ]
-    },
-    {
-      "address": "qzkBLa2rMYmldvjcJLufg9krORJI7UwcVu3YV0eDh1uznmdJ8GfSLWRA",
-      "description": "Generated test vector #117",
-      "expected": [
-        "million",
-        "total",
-        "defense",
-        "alarm",
-        "oval"
-      ]
-    },
-    {
-      "address": "osmo1G9viIGNElLR8abMh0X9zuINamrWtFuaQvSMbkuuP4",
-      "description": "Generated test vector #118",
-      "expected": [
-        "excellent",
-        "forget",
-        "hail",
-        "suggest",
-        "slot"
-      ]
-    },
-    {
-      "address": "0xDM3HuWzUZsStHmQX3v8rb8M0JyK1URtbzEoC",
-      "description": "Generated test vector #119",
-      "expected": [
-        "yummy",
-        "include",
-        "tell",
-        "vibrant",
-        "tourist"
-      ]
-    },
-    {
-      "address": "cosmos1GkxcmfFX4jvD2tuVg8G9mcy1htc02u3gVUbV",
-      "description": "Generated test vector #120",
-      "expected": [
-        "mushroom",
-        "unaffected",
-        "bronze",
-        "adequate",
-        "fame"
-      ]
-    },
-    {
-      "address": "bc1qmrHVPqjh7IgHIq6XJkt3Hdb4dxfyR3NQBwumVYe5VJfXRg",
-      "description": "Generated test vector #121",
-      "expected": [
-        "define",
-        "fiery",
-        "hallmark",
-        "lit",
-        "exchange"
-      ]
-    },
-    {
-      "address": "cosmos1D6i3pwl4u1uEegD0rvJFzSgIesCKopjDemRA8JvRkPTSZhKugBtz",
-      "description": "Generated test vector #122",
-      "expected": [
-        "found",
-        "pave",
-        "move",
-        "certain",
-        "find"
-      ]
-    },
-    {
-      "address": "1uNdniKUYUOCsMBm2sXQ46S49KLF00d38aI8grbAKMSzAnkiI0wzr2",
-      "description": "Generated test vector #123",
-      "expected": [
-        "blossom",
-        "salamander",
-        "flying",
-        "alcohol",
-        "various"
-      ]
-    },
-    {
-      "address": "3aOi2O8iiX13R5MCAYxnAaETSq5JccDwJ7eTG1",
-      "description": "Generated test vector #124",
-      "expected": [
-        "champion",
-        "dedicated",
-        "gold",
-        "acoustic",
-        "deal"
-      ]
-    },
-    {
-      "address": "cosmos1GGLpNPPQHJM4HaC4Juv8skRLsWqNJJOsTbEheWpMrpTL4TOwkWol",
-      "description": "Generated test vector #125",
-      "expected": [
-        "wolf",
-        "buzz",
-        "village",
-        "indicate",
-        "mention"
-      ]
-    },
-    {
-      "address": "vfi5jE9VoBNnTvNUhkysUUHxRDi1a5BQ",
-      "description": "Generated test vector #126",
-      "expected": [
-        "push",
-        "coin",
-        "dolphin",
-        "next",
-        "peanut"
-      ]
-    },
-    {
-      "address": "gGv0LOqqXpKCPoPVGQ9taaezGQvSpcMd",
-      "description": "Generated test vector #127",
-      "expected": [
-        "head",
-        "melody",
-        "elegant",
-        "piece",
-        "figure"
-      ]
-    },
-    {
-      "address": "bc1qRh1iO3J73RpC6N5rA4VukeWxud7qBE5Ll",
-      "description": "Generated test vector #128",
-      "expected": [
-        "height",
-        "strong",
-        "boat",
-        "star",
-        "ally"
-      ]
-    },
-    {
-      "address": "qzkiVnN4SgeJpB3jN5PqR4JF6EB0WWHa7YDJ",
-      "description": "Generated test vector #129",
-      "expected": [
-        "pepper",
-        "wrist",
-        "sleep",
-        "agree",
-        "still"
-      ]
-    },
-    {
-      "address": "osmo1QyN7fH7eCVOkcxlR3NwfNTilSKEdHtHZB9cdWchYPCQ2jJ",
-      "description": "Generated test vector #130",
-      "expected": [
-        "diligent",
-        "plus",
-        "effective",
-        "pigeon",
-        "dune"
-      ]
-    },
-    {
-      "address": "1TEb4MpOaN4YgLZdYhKMdmuZTyhQHt7n",
-      "description": "Generated test vector #131",
-      "expected": [
-        "shine",
-        "system",
-        "eloquence",
-        "female",
-        "predict"
-      ]
-    },
-    {
-      "address": "0xuhizRIB5cg0LWaEalfO2zYVQmNGz6LclE6MWvao",
-      "description": "Generated test vector #132",
-      "expected": [
-        "elder",
-        "glisten",
-        "hope",
-        "doll",
-        "intact"
-      ]
-    },
-    {
-      "address": "18M19FCMmdgj04Ej5dwmpM3CgdHjbFeoBJzU3ogoozm3eKdBnLlxCmwqubJrgCz",
-      "description": "Generated test vector #133",
-      "expected": [
-        "joyful",
-        "buddy",
-        "palace",
-        "burning",
-        "squirrel"
-      ]
-    },
-    {
-      "address": "osmo12LWNLk81f1E9KZrTTpuJ3KjJa8cDVcGDXYCoIaT",
-      "description": "Generated test vector #134",
-      "expected": [
-        "annual",
-        "enjoy",
-        "parade",
-        "plentiful",
-        "accurate"
-      ]
-    },
-    {
-      "address": "bc1qwo9aPkCJK8CiRl2MRaMxQGsURLJmQMu5F4",
-      "description": "Generated test vector #135",
-      "expected": [
-        "turtle",
-        "inform",
-        "baby",
-        "donkey",
-        "creek"
-      ]
-    },
-    {
-      "address": "osmo1gwMwkIeRm8ohD6J7nUnvqQrdvEGh",
-      "description": "Generated test vector #136",
-      "expected": [
-        "pinnacle",
-        "pear",
-        "capital",
-        "other",
-        "beauty"
-      ]
-    },
-    {
-      "address": "3CwPQ82l2fyl7ekgjjm7bzQ5DATblbXZGuJOWEPGICJ3tWoxr0jr7MjHlkR4Xjh9",
-      "description": "Generated test vector #137",
-      "expected": [
-        "polar",
-        "wonder",
-        "east",
-        "into",
-        "initial"
-      ]
-    },
-    {
-      "address": "3qlIctvxHks5zEjCtaT8uRDr68JjJ4BQT3iIty0BfdNKn6rbHBPfFmtL64",
-      "description": "Generated test vector #138",
-      "expected": [
-        "sustain",
-        "humor",
-        "happy",
-        "sort",
-        "talent"
-      ]
-    },
-    {
-      "address": "osmo1j0wxrv82fTB9XrX8A3iKfmD19e7Ufz4zISUilxIcZZsICbaq7Z",
-      "description": "Generated test vector #139",
-      "expected": [
-        "ivory",
-        "chic",
-        "human",
-        "celery",
-        "diary"
-      ]
-    },
-    {
-      "address": "qzkO3zEQphr9eUKJ1MDRhFJ0kdt2ikqA4wrG6",
-      "description": "Generated test vector #140",
-      "expected": [
-        "situate",
-        "remind",
-        "idyllic",
-        "ten",
-        "permissible"
-      ]
-    },
-    {
-      "address": "VlfUH2ZQsQQfJZaGxEv4gjnl3MZGGIUhCeY5DtwY3L",
-      "description": "Generated test vector #141",
-      "expected": [
-        "absent",
-        "active",
-        "prosper",
-        "item",
-        "fertile"
-      ]
-    },
-    {
-      "address": "osmo1SbYn1iohieQWeWUcgXFdhpePUW5m3lvf066v",
-      "description": "Generated test vector #142",
-      "expected": [
-        "invite",
-        "swallow",
-        "unbound",
-        "first",
-        "lake"
-      ]
-    },
-    {
-      "address": "3WMFeYVGS7kUaS550DRlPgZ8AFzVtCGEwrSfExCTQ0oz9A13X6waPPyGPhyR8T",
-      "description": "Generated test vector #143",
-      "expected": [
-        "velvet",
-        "early",
-        "mother",
-        "spare",
-        "layer"
-      ]
-    },
-    {
-      "address": "3wmm0zoAEVVKUX6wP69FjChEo6bTZEblLu",
-      "description": "Generated test vector #144",
-      "expected": [
-        "photo",
-        "inhale",
-        "dedicated",
-        "carefree",
-        "swank"
-      ]
-    },
-    {
-      "address": "cosmos1VOGECsEFHYHbV92hB0BckOW2kAtyV",
-      "description": "Generated test vector #145",
-      "expected": [
-        "jacket",
-        "leader",
-        "budget",
-        "refresh",
-        "dial"
-      ]
-    },
-    {
-      "address": "qzkJD0FyE8Mv8tbcZvUb3vgvwvOpOK4esubuC1J3qRK9xyJYgPuFVvMwBE0W0Hrc",
-      "description": "Generated test vector #146",
-      "expected": [
-        "ratified",
-        "dynamic",
-        "visa",
-        "gesture",
-        "size"
-      ]
-    },
-    {
-      "address": "5M7SJKqJGAveZFsPtzpFPH2MGlEOZ6qNY045TdmCoUV0",
-      "description": "Generated test vector #147",
-      "expected": [
-        "phenomenal",
-        "exchange",
-        "extra",
-        "fiction",
-        "mammal"
-      ]
-    },
-    {
-      "address": "514N0qrjQoojbXtE9A4mqbWrINcSWd3tsd73P2y00oJFhPJWGE",
-      "description": "Generated test vector #148",
-      "expected": [
-        "slush",
-        "survey",
-        "fun",
-        "debris",
-        "matrix"
-      ]
-    },
-    {
-      "address": "1LVtZTXU6ngnrz1dHRhHDprWiDwtO4cTXd4PpxNR3QHoB",
-      "description": "Generated test vector #149",
-      "expected": [
-        "smitten",
-        "office",
-        "general",
-        "suave",
-        "tuna"
-      ]
-    },
-    {
-      "address": "0x54s6Us1jBtYNWqeWET5uA4gjqeATHuRVNlBNamsJgpSVOiKz6B2ik",
-      "description": "Generated test vector #150",
-      "expected": [
-        "mushroom",
-        "slick",
-        "solve",
-        "zippy",
-        "encourage"
-      ]
-    },
-    {
-      "address": "osmo1mzl262n65OM48mRkyAqfw6hSA5CPhSl1WrEi1L9rPzz",
-      "description": "Generated test vector #151",
-      "expected": [
-        "dial",
-        "silly",
-        "trivial",
-        "way",
-        "rally"
-      ]
-    },
-    {
-      "address": "3rqM4wQCaiuQQSRTpfduo4967LUcpMs",
-      "description": "Generated test vector #152",
-      "expected": [
-        "tact",
-        "immune",
-        "lemon",
-        "enroll",
-        "cream"
-      ]
-    },
-    {
-      "address": "5i3clkEvDfSAqt8E8rwA3qZ5GBkTE6I5NBldlDkCh3EB9ICgSjvmr",
-      "description": "Generated test vector #153",
-      "expected": [
-        "upgrade",
-        "barrel",
-        "aspect",
-        "satoshi",
-        "creek"
-      ]
-    },
-    {
-      "address": "3YIPn9aVl5pEfur8hx5gubCRDMqOucMC694Xi1XrXUHLfpoVybmyyO7jsXT54L",
-      "description": "Generated test vector #154",
-      "expected": [
-        "felicity",
-        "property",
-        "brown",
-        "color",
-        "route"
-      ]
-    },
-    {
-      "address": "osmo1ZFE2DIAUYMAAcvCnQjENGsB4Djh30Gs",
-      "description": "Generated test vector #155",
-      "expected": [
-        "caution",
-        "tobacco",
-        "ship",
-        "laptop",
-        "pray"
-      ]
-    },
-    {
-      "address": "0x4FFzCSYwKVbTCW0czRtSUBYv4Yne8qPA",
-      "description": "Generated test vector #156",
-      "expected": [
-        "install",
-        "puzzle",
-        "vigilant",
-        "level",
-        "youth"
-      ]
-    },
-    {
-      "address": "0xyaOCzOUTsYMQ7PXfilYRlbDio01H",
-      "description": "Generated test vector #157",
-      "expected": [
-        "fence",
-        "express",
-        "skirt",
-        "enter",
-        "soap"
-      ]
-    },
-    {
-      "address": "1VjAh3TBEbBpsZyug0AzEJT9cyFS541odbJIqO3hMOBBkTDBF",
-      "description": "Generated test vector #158",
-      "expected": [
-        "catalog",
-        "enjoy",
-        "valor",
-        "type",
-        "illuminate"
-      ]
-    },
-    {
-      "address": "osmo1isS7ZPTXX0MrUPimLgz9smcb2wjZ3bdAMhnpvwc2qjQFPR5BC0ggLW",
-      "description": "Generated test vector #159",
-      "expected": [
-        "phone",
-        "clarify",
-        "candy",
-        "hen",
-        "surprise"
-      ]
-    },
-    {
-      "address": "1FkhmwTRVE1jwYhm8VaZDrkqSzNpUGWi",
-      "description": "Generated test vector #160",
-      "expected": [
-        "label",
-        "gown",
-        "able",
-        "discover",
-        "gain"
-      ]
-    },
-    {
-      "address": "5437GQ6BVSGeuyVAyc5jJ88X28z2R2StvZ3LjzN3MMBvYOW2fHyS2GHn",
-      "description": "Generated test vector #161",
-      "expected": [
-        "electric",
-        "egg",
-        "moral",
-        "describe",
-        "lift"
-      ]
-    },
-    {
-      "address": "GUjbXKoVT9gdxMvcOhsTC8X9J3MHKvrWSPSGpuKZwgSZfd3DB",
-      "description": "Generated test vector #162",
-      "expected": [
-        "epoch",
-        "honey",
-        "bone",
-        "garden",
-        "zeal"
-      ]
-    },
-    {
-      "address": "osmo1yIW2KN9Q6TzkFEC8FGRCcjI5h0gwrGhsxsbiWA6srlTaHecDtCuxZZiiNV",
-      "description": "Generated test vector #163",
-      "expected": [
-        "useful",
-        "diplomat",
-        "ethics",
-        "that",
-        "alert"
-      ]
-    },
-    {
-      "address": "qzk1uXPzoyH73TO1RJXRIhIlMJdJlD3h6lbWpR3",
-      "description": "Generated test vector #164",
-      "expected": [
-        "donate",
-        "sugar",
-        "tooth",
-        "peerless",
-        "timber"
-      ]
-    },
-    {
-      "address": "qzkYLyc1bBz1tphgkipftzkMubdytzuxZhm",
-      "description": "Generated test vector #165",
-      "expected": [
-        "well",
-        "improve",
-        "unity",
-        "render",
-        "have"
-      ]
-    },
-    {
-      "address": "bc1qFF6qtIebN4bIKgVOhJB0FWiHkp77IcY7MOkd5qpQ90n0rkHefRZS92nFX",
-      "description": "Generated test vector #166",
-      "expected": [
-        "renew",
-        "depth",
-        "stereo",
-        "stage",
-        "party"
-      ]
-    },
-    {
-      "address": "osmo18RqPtn7u4i5LaakIREyf2OH3YBh8xLx0Y8hwlaUVQ",
-      "description": "Generated test vector #167",
-      "expected": [
-        "aunt",
-        "such",
-        "usual",
-        "income",
-        "country"
-      ]
-    },
-    {
-      "address": "osmo1fMsSoEwr4RmmYy1JEIOJQJeheqJoGWlQ9QHpI",
-      "description": "Generated test vector #168",
-      "expected": [
-        "formidable",
-        "travel",
-        "blanket",
-        "moment",
-        "unbound"
-      ]
-    },
-    {
-      "address": "qzk6N6d6A9qQCwV2nrABamfJbT8Aep",
-      "description": "Generated test vector #169",
-      "expected": [
-        "loyal",
-        "awesome",
-        "prowess",
-        "sober",
-        "super"
-      ]
-    },
-    {
-      "address": "3tMfDYKMupgovduX6WMVMJfdct0eh4BsMeQIsxfUoLOaxX2Mv6W",
-      "description": "Generated test vector #170",
-      "expected": [
-        "immense",
-        "hat",
-        "various",
-        "uplift",
-        "bean"
-      ]
-    },
-    {
-      "address": "qzkulgKeWmJNpASBpXdtB7Ut2WjtvwaKQdFZ1Amm4WvPR8LuJ7MzkCWcnanoMoT",
-      "description": "Generated test vector #171",
-      "expected": [
-        "noodle",
-        "lifesaver",
-        "nurse",
-        "rabbit",
-        "outer"
-      ]
-    },
-    {
-      "address": "osmo1ml9webhsmKVcbmk2SvIlb04bQxWg6soYO68922ei5XlxxL8pc",
-      "description": "Generated test vector #172",
-      "expected": [
-        "patient",
-        "joyous",
-        "swallow",
-        "suave",
-        "current"
-      ]
-    },
-    {
-      "address": "bc1qsjpNrhFKETWXMky2UxGlSGD7DKNXOm3ConAxj0pfUsGocFuBAwEqbBqe3sFH",
-      "description": "Generated test vector #173",
-      "expected": [
-        "measure",
-        "mesmerize",
-        "sibling",
-        "wire",
-        "mature"
-      ]
-    },
-    {
-      "address": "15gecmmusYQrR99UT4asYWzzJODFVjyoUDFWUSCXtlVRmBI",
-      "description": "Generated test vector #174",
-      "expected": [
-        "hat",
-        "quote",
-        "reveal",
-        "change",
-        "aisle"
-      ]
-    },
-    {
-      "address": "osmo1Jh6aYZvzQzWHubW5j7uNLL18myHlgJB3f",
-      "description": "Generated test vector #175",
-      "expected": [
-        "escape",
-        "medal",
-        "drive",
-        "swarm",
-        "brave"
-      ]
-    },
-    {
-      "address": "1bQEle7roOedGk1zjgHDe71imARDL6KFQraidyYG4",
-      "description": "Generated test vector #176",
-      "expected": [
-        "diplomat",
-        "ginger",
-        "spend",
-        "cherry",
-        "impulse"
-      ]
-    },
-    {
-      "address": "qzkCcfO4v0XyZ0zlMAxORfRc2j2HPeT34zVhwUFWzkmcbNPCvymcpRiPCCf",
-      "description": "Generated test vector #177",
-      "expected": [
-        "portion",
-        "tiger",
-        "shop",
-        "serene",
-        "make"
-      ]
-    },
-    {
-      "address": "bc1qiY0kbgsHyeVPjwncPnRZYNS3ytdaVV5xofA9ulPn2XZkkzguIlmH6h",
-      "description": "Generated test vector #178",
-      "expected": [
-        "immaculate",
-        "order",
-        "tuna",
-        "special",
-        "size"
-      ]
-    },
-    {
-      "address": "bc1qwkytyCeYOwensL8gH90k7L8RQ8RuN2t0",
-      "description": "Generated test vector #179",
-      "expected": [
-        "setup",
-        "citizen",
-        "dawn",
-        "ring",
-        "coin"
-      ]
-    },
-    {
-      "address": "qzkuLKxNoK9oM3tTUMdxsjmc5L6TurNVG8",
-      "description": "Generated test vector #180",
-      "expected": [
-        "pet",
-        "hollow",
-        "follow",
-        "tolerant",
-        "stairs"
-      ]
-    },
-    {
-      "address": "cosmos1oTvmd49XRn2GlNeE7d96hkIX",
-      "description": "Generated test vector #181",
-      "expected": [
-        "swallow",
-        "empower",
-        "toe",
-        "term",
-        "embody"
-      ]
-    },
-    {
-      "address": "bc1qFACkmALsJ7m1D6wxDALAj7DVAf4sHIkxsrIDuSm4a",
-      "description": "Generated test vector #182",
-      "expected": [
-        "found",
-        "piano",
-        "facilitate",
-        "humble",
-        "brilliance"
-      ]
-    },
-    {
-      "address": "E568xENKzc5xJmBp4SFEQRO5TpcYNPROqCQpL70aVN4yK3GlAZps7",
-      "description": "Generated test vector #183",
-      "expected": [
-        "thought",
-        "easy",
-        "sleep",
-        "matrix",
-        "sturdier"
-      ]
-    },
-    {
-      "address": "5TU51gJXYqmURakEgVzzrAkliEFgJnmUYl82B4gNefhdboEVa",
-      "description": "Generated test vector #184",
-      "expected": [
-        "chivalrous",
-        "column",
-        "hockey",
-        "soup",
-        "idyllic"
-      ]
-    },
-    {
-      "address": "cosmos1PWcnXxG7qEULuQvtowyL82X",
-      "description": "Generated test vector #185",
-      "expected": [
-        "all",
-        "burger",
-        "raccoon",
-        "unified",
-        "drift"
-      ]
-    },
-    {
-      "address": "0x1yZ5bhG6UpCQ1FOaN6tN28TQoETXv66DORgxLS12WSbEfZ99C37DHpk6R",
-      "description": "Generated test vector #186",
-      "expected": [
-        "long",
-        "privilege",
-        "advance",
-        "kingdom",
-        "design"
-      ]
-    },
-    {
-      "address": "19b5uxrSP6PP5NEXunJ5ev4USOW7BoqsgvKl6JhtxTtKlyAVX5hPKga0t",
-      "description": "Generated test vector #187",
-      "expected": [
-        "forest",
-        "reflect",
-        "earn",
-        "artefact",
-        "beam"
-      ]
-    },
-    {
-      "address": "cosmos1ECLjPXRLt9h9RDZERx8uZnTYRd1lEy9O09HuQ",
-      "description": "Generated test vector #188",
-      "expected": [
-        "orchard",
-        "brisk",
-        "consider",
-        "debris",
-        "vehicle"
-      ]
-    },
-    {
-      "address": "osmo1yGrRm1yiUJX0RCkiRsinUTaTJQ9j6A05f8ld8OK8MzcoEQ7OxQ",
-      "description": "Generated test vector #189",
-      "expected": [
-        "turkey",
-        "family",
-        "spring",
-        "octopus",
-        "melt"
-      ]
-    },
-    {
-      "address": "11OrOwhfEPFbJJqUXlENAJgd4XlYbIHYEGKSWhU73lLlIXhhmjI0c8FwHA6",
-      "description": "Generated test vector #190",
-      "expected": [
-        "summer",
-        "cool",
-        "record",
-        "recipe",
-        "patriot"
-      ]
-    },
-    {
-      "address": "0xs6GWOBJRG9vHngYolsZ7LnwhMepx4yfpARHeT9RlxOY",
-      "description": "Generated test vector #191",
-      "expected": [
-        "ingenious",
-        "book",
-        "empire",
-        "crowd",
-        "tip"
-      ]
-    },
-    {
-      "address": "3YtWx7pqGQzuf4WjXqg8n7WhG2KYfvJrqgctUlXQWI2yKqQSOiJq4NwW",
-      "description": "Generated test vector #192",
-      "expected": [
-        "ranch",
-        "bag",
-        "wolf",
-        "thumb",
-        "pelican"
-      ]
-    },
-    {
-      "address": "5l9XFrA62Ys16ztfeT6kdUIE27AFTDF93RzM4USRUpT6Z2GLL7P2Gne0F7A",
-      "description": "Generated test vector #193",
-      "expected": [
-        "guess",
-        "next",
-        "buzz",
-        "empire",
-        "clap"
-      ]
-    },
-    {
-      "address": "5xh4pHVhssnTJns5NZcCMEwMuva3lvgEfFjhEjOo",
-      "description": "Generated test vector #194",
-      "expected": [
-        "earn",
-        "lunch",
-        "hybrid",
-        "shiver",
-        "tops"
-      ]
-    },
-    {
-      "address": "5sAlYgB0kvAw1mlcyU3jmDPqAIXSuV2F50yggbjFVoQv8TArEVpjF",
-      "description": "Generated test vector #195",
-      "expected": [
-        "memory",
-        "praise",
-        "broom",
-        "mansion",
-        "region"
-      ]
-    },
-    {
-      "address": "bc1qV19pYmRYRFl9KNoic95AMfdzsNouDFNsqrvztccdUnD",
-      "description": "Generated test vector #196",
-      "expected": [
-        "kiwi",
-        "vigilant",
-        "fiber",
-        "ability",
-        "avocado"
-      ]
-    },
-    {
-      "address": "1l6wsgaI1uTwWGxOnx3iUhK4OlR5eHvS9mSclIp20483BS4ez5FbLRhcJ",
-      "description": "Generated test vector #197",
-      "expected": [
-        "staff",
-        "clarify",
-        "puppy",
-        "tattoo",
-        "toy"
-      ]
-    },
-    {
-      "address": "bc1qEHFeBFIyLmaJKa5FFSq0sqhnHsN6ri2d89nhON8u62qi3s9MawT",
-      "description": "Generated test vector #198",
-      "expected": [
-        "cohere",
-        "landmark",
-        "agent",
-        "doll",
-        "spot"
-      ]
-    },
-    {
-      "address": "cosmos1paO16KSQ6pMLmBumN1yBTAjDECYkJ6lrt2",
-      "description": "Generated test vector #199",
-      "expected": [
-        "pass",
-        "mind",
-        "purpose",
-        "alone",
-        "bachelor"
-      ]
-    },
-    {
-      "address": "5eep48gGTYLxbZVNcpfiMa77gTuRmDIBkujdQMhZgs",
-      "description": "Generated test vector #200",
-      "expected": [
-        "pony",
-        "bear",
-        "field",
-        "slender",
-        "tomato"
-      ]
-    },
-    {
-      "address": "i4bAjOo2x2Zgkgg7wMh553LlGLQjPsYvg4P5YSea5jOtySWDeJ7rf9lx",
-      "description": "Generated test vector #201",
-      "expected": [
-        "wing",
-        "swift",
-        "element",
-        "ask",
-        "melt"
-      ]
-    },
-    {
-      "address": "osmo1AQzXuXOpzEHHYxKAJQURoa9bI75dv01Ysi084pZdi7Rxb7xRPeZ1bwee",
-      "description": "Generated test vector #202",
-      "expected": [
-        "venture",
-        "exemplar",
-        "praise",
-        "ardor",
-        "doll"
-      ]
-    },
-    {
-      "address": "5VDiG6DSBNagdNLkjyA6CSpJso5qfx6UydyY8Le",
-      "description": "Generated test vector #203",
-      "expected": [
-        "metal",
-        "dutch",
-        "tag",
-        "chime",
-        "general"
-      ]
-    },
-    {
-      "address": "qzktNZkXOmgeL0brHeLUtINcq8JIWct6awrymUS8RgzTgYjKxK0rjC2fS2YO",
-      "description": "Generated test vector #204",
-      "expected": [
-        "poppy",
-        "seminar",
-        "verify",
-        "twin",
-        "breeze"
-      ]
-    },
-    {
-      "address": "3GTO5vWvw1A3VymLejMEXi1H8Wfft5krwflVpDp2OihJc1y14hw07xQFq2QMNT",
-      "description": "Generated test vector #205",
-      "expected": [
-        "lady",
-        "won",
-        "grid",
-        "lesson",
-        "polar"
-      ]
-    },
-    {
-      "address": "bc1qjgxJ0n2PvDHYglg7yAydvLnThC",
-      "description": "Generated test vector #206",
-      "expected": [
-        "ginger",
-        "lottery",
-        "pupil",
-        "auto",
-        "few"
-      ]
-    },
-    {
-      "address": "6jnJ9WdYW8nnbVApkiqf2BAn3ld3A7sm6DHW7B4",
-      "description": "Generated test vector #207",
-      "expected": [
-        "flavor",
-        "route",
-        "letter",
-        "misery",
-        "zeal"
-      ]
-    },
-    {
-      "address": "5I3mSJiPZTZTa35EtXPqS961NNJcUl",
-      "description": "Generated test vector #208",
-      "expected": [
-        "attend",
-        "loving",
-        "boost",
-        "neat",
-        "eagle"
-      ]
-    },
-    {
-      "address": "LnnlQ7wwstYhE9zvZA8u5CxIkBrOQNR64gfZfb5g",
-      "description": "Generated test vector #209",
-      "expected": [
-        "kingdom",
-        "word",
-        "appear",
-        "pioneer",
-        "blockbuster"
-      ]
-    },
-    {
-      "address": "NFXP0nWIh16vXC4NWy6WFqOt34Pa4cbX0GTt",
-      "description": "Generated test vector #210",
-      "expected": [
-        "blessing",
-        "rally",
-        "wieldy",
-        "tourist",
-        "craft"
-      ]
-    },
-    {
-      "address": "3o8lNZXJhN8k4GBgXFNW0MqI6mfBMKbR5exUiCNwo3sHpWWVOr5MNJgCK",
-      "description": "Generated test vector #211",
-      "expected": [
-        "shell",
-        "fix",
-        "scale",
-        "museum",
-        "screen"
-      ]
-    },
-    {
-      "address": "1r3fEwZyEbe7eQxt4YlalJLb89EMHjT5lbbFj1h",
-      "description": "Generated test vector #212",
-      "expected": [
-        "web",
-        "prize",
-        "fulfill",
-        "candy",
-        "first"
-      ]
-    },
-    {
-      "address": "bc1qunT6qD7vIsUEFylkQ3ryKVtX7E2",
-      "description": "Generated test vector #213",
-      "expected": [
-        "encrypt",
-        "dish",
-        "tiny",
-        "valve",
-        "punctual"
-      ]
-    },
-    {
-      "address": "5YMLAJxNdkcFKsZN7vbluXweOxWhtauCX3IxLGgrL21e3AU",
-      "description": "Generated test vector #214",
-      "expected": [
-        "faucet",
-        "attune",
-        "birth",
-        "vested",
-        "umbrella"
-      ]
-    },
-    {
-      "address": "osmo1mdEcrhCLKobbWJaCi7cHGubDZzstveWEcs9EN406gnZi9",
-      "description": "Generated test vector #215",
-      "expected": [
-        "yard",
-        "fresh",
-        "someone",
-        "adorable",
-        "announce"
-      ]
-    },
-    {
-      "address": "5kl3w3951qWg6euLYqkiCh1U37zBhGJO8tToqsfI2OTm",
-      "description": "Generated test vector #216",
-      "expected": [
-        "choose",
-        "palace",
-        "strategy",
-        "best",
-        "couple"
-      ]
-    },
-    {
-      "address": "18danYlgmKG1VtCjF4nw81FWlrkt1Oj2Uo",
-      "description": "Generated test vector #217",
-      "expected": [
-        "salt",
-        "picnic",
-        "chime",
-        "link",
-        "myself"
-      ]
-    },
-    {
-      "address": "qzkqDGvhIvnyAuBwdx5mlkrLGgdpgh3JoGr2RzynZ",
-      "description": "Generated test vector #218",
-      "expected": [
-        "dad",
-        "burst",
-        "gospel",
-        "direct",
-        "unity"
-      ]
-    },
-    {
-      "address": "cosmos1mWvrKTfFRDs4otel3iaDulqeQ0K8KEpgYJ9ZGkjfsTCT9pEwavS3W1",
-      "description": "Generated test vector #219",
-      "expected": [
-        "attend",
-        "split",
-        "forward",
-        "empathize",
-        "service"
-      ]
-    },
-    {
-      "address": "qzkqGNjzn9wbJRAmf5xgqMH492k4vuK6rlJRZ",
-      "description": "Generated test vector #220",
-      "expected": [
-        "bid",
-        "core",
-        "cricket",
-        "muscle",
-        "essence"
-      ]
-    },
-    {
-      "address": "1XJXvga5jQGrIkEesCnZhEavZdi2WF7I7SiTA4sb5pQxy435LkB2XiVpz",
-      "description": "Generated test vector #221",
-      "expected": [
-        "dazzling",
-        "shop",
-        "coconut",
-        "mechanic",
-        "grateful"
-      ]
-    },
-    {
-      "address": "bc1qss5ClWZfGRFQwvC7C4bVfi4WJxM32d0hPCVG0fq9gKYJQ",
-      "description": "Generated test vector #222",
-      "expected": [
-        "flex",
-        "mind",
-        "medal",
-        "floor",
-        "flexible"
-      ]
-    },
-    {
-      "address": "0xTPTdmiTEnP0st9aEQhaLhgmDZBdhz8Y0HYQ",
-      "description": "Generated test vector #223",
-      "expected": [
-        "exemplar",
-        "tobacco",
-        "brilliance",
-        "action",
-        "kingdom"
-      ]
-    },
-    {
-      "address": "1jbiUoFRmDrgKwrxXCYjrhyJcOOB4vi2CajF1n3GFkjOIC1iWO5e0D7Ll",
-      "description": "Generated test vector #224",
-      "expected": [
-        "affluence",
-        "just",
-        "giant",
-        "harbor",
-        "october"
-      ]
-    },
-    {
-      "address": "qRKKKZebToPEQuoV4Xg2Tx85dpcUBxNbkgBiNImEQnUAGWfb7fciaWJ1vQ7TGlm",
-      "description": "Generated test vector #225",
-      "expected": [
-        "shoe",
-        "egg",
-        "train",
-        "dynamic",
-        "coffee"
-      ]
-    },
-    {
-      "address": "qzkvMIieAxeeWshoLun65pRe28eJ05FydRgD4qbuquViHT5P2oe64RVc86LLeI",
-      "description": "Generated test vector #226",
-      "expected": [
-        "govern",
-        "blameless",
-        "soap",
-        "pact",
-        "east"
-      ]
-    },
-    {
-      "address": "3SgEnvDW2o5bWmLxQbDyxhRIhhM4vv4ofazUYHcX2pddBrt",
-      "description": "Generated test vector #227",
-      "expected": [
-        "surface",
-        "seminar",
-        "crystal",
-        "child",
-        "fan"
-      ]
-    },
-    {
-      "address": "bc1qiyOOe6mRY31BswI1p3tHgvz6Ee40GsIhSWcoBV7bZqKs",
-      "description": "Generated test vector #228",
-      "expected": [
-        "garden",
-        "admit",
-        "curtain",
-        "popular",
-        "venerate"
-      ]
-    },
-    {
-      "address": "1rLE1xcmlAdsHvbL354YKUvZAATTdgySQ",
-      "description": "Generated test vector #229",
-      "expected": [
-        "bonus",
-        "violin",
-        "congress",
-        "original",
-        "chat"
-      ]
-    },
-    {
-      "address": "ASVq7C9o4rQr9VsJcrqpOVatOZ0BbacwNIzJe3I7BpWqEok2OoOlFBtIo79",
-      "description": "Generated test vector #230",
-      "expected": [
-        "limit",
-        "horse",
-        "godlike",
-        "permissible",
-        "tissue"
-      ]
-    },
-    {
-      "address": "cosmos1Q1vSLveBFouxZzN2iuWuzOD8",
-      "description": "Generated test vector #231",
-      "expected": [
-        "preeminent",
-        "toast",
-        "business",
-        "domain",
-        "razor"
-      ]
-    },
-    {
-      "address": "0xwsjKgntSUWS6xKOjVO779J9NTHh2XLOGtmJ4uX",
-      "description": "Generated test vector #232",
-      "expected": [
-        "guess",
-        "wish",
-        "wide",
-        "trumpet",
-        "tidy"
-      ]
-    },
-    {
-      "address": "osmo1CUhoT2wvF4OLBzJZhHWzKiqrtfA8JNV32ahqI5U",
-      "description": "Generated test vector #233",
-      "expected": [
-        "romance",
-        "belt",
-        "spirit",
-        "stunning",
-        "royal"
-      ]
-    },
-    {
-      "address": "3ZbkeFGyAhRosuZuLgSe564NTBURTSKY",
-      "description": "Generated test vector #234",
-      "expected": [
-        "idyllic",
-        "trigger",
-        "possible",
-        "equal",
-        "course"
-      ]
-    },
-    {
-      "address": "jaKPCtkSrVoEcGGF5rxU7c62TAr2tvkrEnk",
-      "description": "Generated test vector #235",
-      "expected": [
-        "film",
-        "finish",
-        "captain",
-        "ship",
-        "glide"
-      ]
-    },
-    {
-      "address": "cosmos15Pim0Ub37HXaZbm6JTGZsgR0BAq19",
-      "description": "Generated test vector #236",
-      "expected": [
-        "setup",
-        "elan",
-        "pet",
-        "hotel",
-        "print"
-      ]
-    },
-    {
-      "address": "1XUnejuCTPeQ3cgRGlIZM6MpK2nmDElEiNfGSnAELScQMNovG720",
-      "description": "Generated test vector #237",
-      "expected": [
-        "arena",
-        "hollow",
-        "fruit",
-        "hollow",
-        "elbow"
-      ]
-    },
-    {
-      "address": "cosmos1ENLHsn73VABpAk7Ovyh201LQbqn0zIuPzYAqdEnNcBn2HWg8LiH6bx",
-      "description": "Generated test vector #238",
-      "expected": [
-        "train",
-        "novel",
-        "tonight",
-        "flourish",
-        "notice"
-      ]
-    },
-    {
-      "address": "osmo1VIOGwmjH1oX4unT6cb6gyEjsoVpqhWOiTqfeSVzaZLjTXmL",
-      "description": "Generated test vector #239",
-      "expected": [
-        "menu",
-        "expect",
-        "crucial",
-        "image",
-        "forget"
-      ]
-    },
-    {
-      "address": "cosmos1AUsCg8JxAnzrrRFx9T6VSCJbVBDgtiNfIm6KfyZG0Vd",
-      "description": "Generated test vector #240",
-      "expected": [
-        "sophisticated",
-        "wonder",
-        "diary",
-        "talk",
-        "catch"
-      ]
-    },
-    {
-      "address": "qzkzTZcQL2qmIEE7oCDITT5AehaGhm1h2EMGi2zah9S2qt",
-      "description": "Generated test vector #241",
-      "expected": [
-        "high",
-        "drink",
-        "tissue",
-        "snazzy",
-        "bachelor"
-      ]
-    },
-    {
-      "address": "osmo1iGmMSGpC65S0iGZazje8tlRHudDjvIoM5rY",
-      "description": "Generated test vector #242",
-      "expected": [
-        "spice",
-        "nice",
-        "smooth",
-        "pyramid",
-        "smitten"
-      ]
-    },
-    {
-      "address": "5wV5INmKgnlIhGNxJ0L7TM4maon5MiDae8iYADsVoyVRwZteL",
-      "description": "Generated test vector #243",
-      "expected": [
-        "logic",
-        "gusto",
-        "formidable",
-        "exemplar",
-        "cradle"
-      ]
-    },
-    {
-      "address": "bc1q6ZS0IEWQIAvbwCPTnI96xlUaBGatfwp5LcrD",
-      "description": "Generated test vector #244",
-      "expected": [
-        "concert",
-        "culture",
-        "unabashed",
-        "epoch",
-        "landmark"
-      ]
-    },
-    {
-      "address": "0xqdJbSDLCkUOHgwMSRk0fZhBSt1r0OTuP33k9SwaPzPdl",
-      "description": "Generated test vector #245",
-      "expected": [
-        "copper",
-        "tobacco",
-        "alive",
-        "flavor",
-        "canyon"
-      ]
-    },
-    {
-      "address": "TfBrmFkUZaqvvJRJChfTlK7VWnxfSpZN3lUidRl",
-      "description": "Generated test vector #246",
-      "expected": [
-        "arch",
-        "zone",
-        "sturdier",
-        "echo",
-        "decide"
-      ]
-    },
-    {
-      "address": "3zZqm8qBfwwVGZQk6KjJ9AOQrv8IUqFnnq5GNDCuIO3tgw3jDu",
-      "description": "Generated test vector #247",
-      "expected": [
-        "melody",
-        "walnut",
-        "banner",
-        "landmark",
-        "hero"
-      ]
-    },
-    {
-      "address": "14sClbYCJAyZpxuQs82V3FAV7ybF5276m8Uiu78tV",
-      "description": "Generated test vector #248",
-      "expected": [
-        "siege",
-        "beach",
-        "sentence",
-        "tulip",
-        "luxury"
-      ]
-    },
-    {
-      "address": "osmo1yCOmktl1BSjIWajgIynDxCp4yt5yurP2LHvP8b2lowFaLyeoEcsfxl",
-      "description": "Generated test vector #249",
-      "expected": [
-        "tingle",
-        "daring",
-        "crush",
-        "satoshi",
-        "spatial"
-      ]
-    },
-    {
-      "address": "3tPDq7lyGgXvTOzYjhFQaOPAdAUhY4FWS08glAV1ea6RpFM2",
-      "description": "Generated test vector #250",
-      "expected": [
-        "hold",
-        "post",
-        "curve",
-        "toddler",
-        "laptop"
-      ]
-    },
-    {
-      "address": "5Cc1CdLwAPVbqszBscgTGykHhiE3vCM44",
-      "description": "Generated test vector #251",
-      "expected": [
-        "afford",
-        "local",
-        "cash",
-        "buddy",
-        "system"
-      ]
-    },
-    {
-      "address": "cucLSYgFSuNsylUSUe47XJ9MHXRdJn5rQlFcylramWOrCWNgnRnLTLCAKHD",
-      "description": "Generated test vector #252",
-      "expected": [
-        "fossil",
-        "fascinate",
-        "fan",
-        "act",
-        "moment"
-      ]
-    },
-    {
-      "address": "vtZj0EGkyyOJeE9fUGsUBCjKMJzVUr",
-      "description": "Generated test vector #253",
-      "expected": [
-        "dauntless",
-        "jaguar",
-        "copy",
-        "february",
-        "hidden"
-      ]
-    },
-    {
-      "address": "qzkxHx6hyngr1V98Ivn3rVNPQNNFHnzUr5j2yaZVOQgJz",
-      "description": "Generated test vector #254",
-      "expected": [
-        "electric",
-        "square",
-        "hallmark",
-        "feature",
-        "thought"
-      ]
-    },
-    {
-      "address": "5lbnLFeJzbLkMQ7bLWyFl4CSoDSmiebJCQBokCNXZ24pSeUQzGDxW72H",
-      "description": "Generated test vector #255",
-      "expected": [
-        "expire",
-        "almost",
-        "object",
-        "mother",
-        "spell"
-      ]
-    },
-    {
-      "address": "BZdYZScy5NBWg0UJXSwOipDquRCRUUv",
-      "description": "Generated test vector #256",
-      "expected": [
-        "slab",
-        "sponsor",
-        "awesome",
-        "tomorrow",
-        "marvel"
-      ]
-    },
-    {
-      "address": "qzkWRJKVjrnwws6jNDBsURjsxNbnsKqSU9zMkvj0tx1EkGk3a6v",
-      "description": "Generated test vector #257",
-      "expected": [
-        "note",
-        "update",
-        "museum",
-        "throw",
+      "description": "Generated test vector #68",
+      "expected": [
+        "bring",
+        "dear",
+        "country",
+        "upheld",
         "panther"
       ]
     },
     {
-      "address": "cosmos1nrWWOwC4400WGomPygueIHT28dJppTQOpQCc",
-      "description": "Generated test vector #258",
+      "address": "5V1YFjtFi02blZZpC4RqZFNhbxKl1Kvk3UQrxkJ71OQqzbWVa4OLapXs7NAxv",
+      "description": "Generated test vector #69",
       "expected": [
-        "chill",
-        "doctor",
-        "giggle",
-        "truck",
-        "toward"
+        "diary",
+        "youth",
+        "raven",
+        "daring",
+        "hobby"
       ]
     },
     {
-      "address": "cosmos1flZd3GdoKKCHWtNmhfmHnEJK1g2WmXMCaULEkFF6",
-      "description": "Generated test vector #259",
+      "address": "cosmos1CPZygFP0xOLsgd9N1qS3sjV3XXLOQSO9qzyc",
+      "description": "Generated test vector #70",
       "expected": [
-        "chef",
-        "proof",
-        "girl",
-        "wide",
-        "gusto"
+        "team",
+        "tell",
+        "bench",
+        "first",
+        "luster"
       ]
     },
     {
-      "address": "cosmos11prItB86Et8DkeAs5BNHlWVnFtGgsLJjjVW0Lj7",
-      "description": "Generated test vector #260",
+      "address": "bc1qTnHW4PF002lghqYVlQufwUtWuqs0D1K6e3F1xsd0imzJ4Ct",
+      "description": "Generated test vector #71",
+      "expected": [
+        "upbeat",
+        "hollow",
+        "decorate",
+        "ambitious",
+        "paper"
+      ]
+    },
+    {
+      "address": "3ENkNaqVkVEVfMNz7xcmxatZlPMpQvhxKkZ",
+      "description": "Generated test vector #72",
+      "expected": [
+        "honor",
+        "between",
+        "dao",
+        "tranquil",
+        "palm"
+      ]
+    },
+    {
+      "address": "cosmos1CGGAQi9EUk4Ybn9nbFhSXxNVMKcgZchBhpRmQaAgG",
+      "description": "Generated test vector #73",
+      "expected": [
+        "rabbit",
+        "glide",
+        "myth",
+        "efficient",
+        "wear"
+      ]
+    },
+    {
+      "address": "3ZgShhgmmqGmRscEm5uaP4ZPjfFSgpo9sCgkcsXtTfVc0PkwBM2fYly7",
+      "description": "Generated test vector #74",
+      "expected": [
+        "ability",
+        "window",
+        "material",
+        "boom",
+        "ceiling"
+      ]
+    },
+    {
+      "address": "cosmos1QDA2kiT80g4DJBLWL12T3DE3BdOa1GUSn72GQMATDPNjZ3M",
+      "description": "Generated test vector #75",
       "expected": [
         "few",
-        "have",
-        "sponsor",
-        "place",
-        "matrix"
+        "tenant",
+        "pray",
+        "catalog",
+        "cereal"
       ]
     },
     {
-      "address": "qzkWq5D1siuvUBAyzVz8vX8VbRmSsxtXuImnF1gpuDSD8cOQ4ErLxgNr",
-      "description": "Generated test vector #261",
+      "address": "0xFDEkUturFIxYeBJfEt8UbzcIZX7N3IOCvZY0uV",
+      "description": "Generated test vector #76",
       "expected": [
-        "bone",
-        "marble",
-        "cloth",
-        "novel",
+        "love",
+        "geekier",
+        "night",
+        "cloud",
         "expand"
       ]
     },
     {
-      "address": "osmo15giUuWzjjsmfpJVqGsbVeWSt04B2lDCuQRpUbhzyEcG4FbBbFXWEJ",
-      "description": "Generated test vector #262",
+      "address": "qzkShVnvZ7sGRckiSSgLl5yCWSgz5ZKVBO7iEGd50DF5kJThyL2Fx",
+      "description": "Generated test vector #77",
       "expected": [
-        "keep",
-        "film",
-        "sun",
-        "foolproof",
-        "produce"
-      ]
-    },
-    {
-      "address": "1J8WGX0f5L9UVArB2TOeOvGQYAbJaZbnAq",
-      "description": "Generated test vector #263",
-      "expected": [
-        "aspiration",
-        "convince",
-        "afford",
-        "laundry",
-        "length"
-      ]
-    },
-    {
-      "address": "bc1qHOmY53SJljtgH6chve15Omk9o5Vb26h6b10mdBmVKh8FJG",
-      "description": "Generated test vector #264",
-      "expected": [
-        "gesture",
-        "industry",
-        "inner",
-        "lucid",
-        "chest"
-      ]
-    },
-    {
-      "address": "3hELUtl9XwpgCaXy1v6ZA0s9fNyD6rOuipJhjRVdX1O",
-      "description": "Generated test vector #265",
-      "expected": [
-        "keypair",
-        "voice",
-        "size",
-        "blush",
-        "year"
-      ]
-    },
-    {
-      "address": "osmo1ZzkGjYPw5Wbmzx0MbbbDTizHVSkgvnAe8Cz3B1YaD3puH7PfEZJ",
-      "description": "Generated test vector #266",
-      "expected": [
-        "slab",
-        "trend",
-        "infant",
-        "when",
-        "position"
-      ]
-    },
-    {
-      "address": "3FXiOUSrMppTsSCKG9q3uxjT0UXNX8aNZoyaD1l18z9C",
-      "description": "Generated test vector #267",
-      "expected": [
-        "team",
-        "mesmerize",
-        "boat",
-        "ledger",
-        "spice"
-      ]
-    },
-    {
-      "address": "cosmos1BUOFu9lv2VCf1VqWAbHf8ZhShvCI678lY2FiQWmUGWIGcHHR9kjQN1o5S",
-      "description": "Generated test vector #268",
-      "expected": [
-        "eagle",
-        "quality",
-        "picture",
-        "door",
-        "dress"
-      ]
-    },
-    {
-      "address": "1r76s383Di6apIt5M7dziYVY6pWOylZe7r3hT6jBPVahtgMDOshUCe84v",
-      "description": "Generated test vector #269",
-      "expected": [
-        "chuckle",
-        "dear",
-        "facilitate",
-        "joyful",
-        "lavish"
-      ]
-    },
-    {
-      "address": "cosmos1x3gCK2QXVng9LLw1PZ7AN1rSr",
-      "description": "Generated test vector #270",
-      "expected": [
-        "often",
-        "authentic",
-        "vigor",
-        "famous",
-        "witty"
-      ]
-    },
-    {
-      "address": "cosmos1uPpwaSEKnAq9ZELJL1PcgZNgf7oJRLYScOBC1cyXUA4nlNuszbC3wQv",
-      "description": "Generated test vector #271",
-      "expected": [
-        "tilt",
-        "fortune",
-        "gorilla",
-        "legend",
-        "empire"
-      ]
-    },
-    {
-      "address": "bc1qBcC9qXmVHtyvY01uMTZoZgSNtElxqRvX3U7ugK4RIUH",
-      "description": "Generated test vector #272",
-      "expected": [
-        "split",
-        "bright",
-        "athlete",
-        "gossip",
-        "haunting"
-      ]
-    },
-    {
-      "address": "5mfL2zqSHy5g7Y3sJf9BcHPqEZ8poOnapb",
-      "description": "Generated test vector #273",
-      "expected": [
-        "tranquil",
-        "avocado",
-        "drill",
-        "soup",
-        "any"
-      ]
-    },
-    {
-      "address": "qzkzIJz0KM38UR8Xqw36tw7i19pHh8WFDtYLSSNI9CJdMEB7kIIdv1jQeS",
-      "description": "Generated test vector #274",
-      "expected": [
-        "invulnerable",
-        "pumpkin",
-        "anew",
-        "lobster",
-        "turn"
-      ]
-    },
-    {
-      "address": "cosmos1SER69nCHPuJ26iHQtaLSwh8M",
-      "description": "Generated test vector #275",
-      "expected": [
-        "chief",
-        "unveil",
-        "metal",
-        "embark",
-        "patient"
-      ]
-    },
-    {
-      "address": "TTpLVllOEhf6J6yzRivfwR2Elyo9NvUGbL8dxk7Gaxb4I17lMlnv24LJ",
-      "description": "Generated test vector #276",
-      "expected": [
-        "evocative",
-        "toddler",
-        "gentle",
-        "between",
-        "only"
-      ]
-    },
-    {
-      "address": "qzkFYBM53Xh55gQKkgljMuCOZW6Pepi7EXcd8D0OU",
-      "description": "Generated test vector #277",
-      "expected": [
-        "phenomenal",
-        "click",
-        "gecko",
-        "enlist",
-        "situate"
-      ]
-    },
-    {
-      "address": "1fO4IRGUNriVsMzxEEtEyEWrQdZlf3UJktcb7xvHZQAF0FQcnClntSEJMcx3hs4",
-      "description": "Generated test vector #278",
-      "expected": [
-        "gentle",
-        "haunting",
-        "index",
-        "letter",
-        "spread"
-      ]
-    },
-    {
-      "address": "osmo19ZxZcipP2AJ1Mm2TqQzzr3YELMyRBPnNh3El",
-      "description": "Generated test vector #279",
-      "expected": [
-        "blockbuster",
-        "avocado",
-        "durable",
-        "kitten",
-        "snack"
-      ]
-    },
-    {
-      "address": "osmo16pQ5yHrJghZ26IEh9DgoZlVXoMBiLc5Vlnt",
-      "description": "Generated test vector #280",
-      "expected": [
-        "durable",
-        "coral",
-        "homage",
-        "hidden",
-        "escape"
-      ]
-    },
-    {
-      "address": "0xv65vmNyjsdlmOB2epGIi7dQzHMk5wigoxIYVh",
-      "description": "Generated test vector #281",
-      "expected": [
-        "unified",
-        "cooperate",
-        "keypair",
-        "grand",
-        "chic"
-      ]
-    },
-    {
-      "address": "bc1qIeO46NrMBUQLv9C5jHwiNk792wbX",
-      "description": "Generated test vector #282",
-      "expected": [
-        "dust",
-        "desert",
-        "cloud",
-        "uphold",
-        "stone"
-      ]
-    },
-    {
-      "address": "3CSHoy0v6AzTBywuySmnlm2OM3HVzNni",
-      "description": "Generated test vector #283",
-      "expected": [
-        "help",
-        "glamorous",
-        "already",
-        "coyote",
-        "depend"
-      ]
-    },
-    {
-      "address": "1OsZWMdnIjxGlBRxPqUIjyWmzD1i5t5LT2PWfa1d0t3mjn0w4KZDRrgI3jzHMjID",
-      "description": "Generated test vector #284",
-      "expected": [
-        "champion",
-        "wear",
-        "because",
-        "merge",
-        "flower"
-      ]
-    },
-    {
-      "address": "cosmos18PjBUixxkbQY5Kl386J292eisyj9XP7tS6fLXa",
-      "description": "Generated test vector #285",
-      "expected": [
-        "pink",
-        "depth",
-        "vital",
-        "where",
-        "flock"
-      ]
-    },
-    {
-      "address": "5wpF84btkORq9uq9OOub25aJsmDyRqxwF9ARivql",
-      "description": "Generated test vector #286",
-      "expected": [
-        "haunting",
-        "olive",
-        "enchant",
-        "witness",
-        "network"
-      ]
-    },
-    {
-      "address": "cosmos1fBPX413bhVpkeJofeSTv4eK78NuPLdi45lSfAQnS",
-      "description": "Generated test vector #287",
-      "expected": [
-        "ovation",
-        "salient",
-        "arrow",
-        "twice",
-        "face"
-      ]
-    },
-    {
-      "address": "5MlYRERDTK1BFe8q2JlhVl0UoyZszNnpvoa3QrjdE3dUAP3B8P",
-      "description": "Generated test vector #288",
-      "expected": [
-        "protect",
-        "guess",
-        "invaluable",
-        "draw",
-        "panel"
-      ]
-    },
-    {
-      "address": "osmo1RL7JTtwYwsEHUokQz2uX6z1CjTx62Wx1jwAY4j6nbDqmEjZ0",
-      "description": "Generated test vector #289",
-      "expected": [
-        "ripple",
-        "superb",
-        "light",
-        "tribe",
-        "huge"
-      ]
-    },
-    {
-      "address": "cosmos1lLEA0EPvg7RLiGEnE7NutMLLGvxQhJDbwp6Q4",
-      "description": "Generated test vector #290",
-      "expected": [
-        "auspicious",
-        "amicable",
-        "giraffe",
-        "planet",
-        "salt"
-      ]
-    },
-    {
-      "address": "osmo1WIJumhtN8oKoYEDbFfUMfEL37qBWXri0dpNuZDjqt9LHZO7LhTTmXrX",
-      "description": "Generated test vector #291",
-      "expected": [
-        "legend",
-        "adapt",
-        "embrace",
-        "chapter",
-        "glove"
-      ]
-    },
-    {
-      "address": "5smsbNAwW9BxjBt6CmLrKubduDiZxb",
-      "description": "Generated test vector #292",
-      "expected": [
-        "legend",
-        "venerate",
-        "jewel",
-        "ask",
-        "ripple"
-      ]
-    },
-    {
-      "address": "5yuZcrJJ2dSidejG6oU8uzUEHGNyjZYBh4qoNId0ncnoj1FuUP",
-      "description": "Generated test vector #293",
-      "expected": [
-        "culture",
-        "recall",
-        "light",
-        "volume",
-        "castle"
-      ]
-    },
-    {
-      "address": "0xVEPRIcKmKaRKw3knH4UrIFjmLuuqhrbLOFzlcXU2mJUZP2YwdMJ2pFtnluES",
-      "description": "Generated test vector #294",
-      "expected": [
-        "material",
-        "metal",
-        "young",
-        "coach",
-        "view"
-      ]
-    },
-    {
-      "address": "osmo19LkEIr91pM20M165sxJjdnlA2ezbV3sq53Xm5UQb5Dafo1JIqRDTje",
-      "description": "Generated test vector #295",
-      "expected": [
-        "zebra",
-        "crush",
-        "antenna",
-        "trumpet",
-        "star"
-      ]
-    },
-    {
-      "address": "5cACka3O72SSmqP7lQY9cI1IRXSUrfw",
-      "description": "Generated test vector #296",
-      "expected": [
-        "unabashed",
-        "favorite",
-        "holy",
-        "ramp",
-        "boost"
-      ]
-    },
-    {
-      "address": "qzkkOxIjTvkyCvsYUEHwAL2uwCU1kcF1MLHZjXiYmQfzgFcga5PkoSuhTXIyOyJU",
-      "description": "Generated test vector #297",
-      "expected": [
-        "luggage",
-        "recall",
-        "viable",
-        "sober",
-        "hottest"
-      ]
-    },
-    {
-      "address": "1NCZ3laXFgie6ozZHfYbbhlWep6AwyRsymAKDMcEbtbR",
-      "description": "Generated test vector #298",
-      "expected": [
-        "violin",
-        "mint",
-        "april",
-        "second",
-        "stable"
-      ]
-    },
-    {
-      "address": "5VAK26Q9x7VfpfpZNfxuLDuIRBMfQKPbFelrJXHSphGkC0cLAQ8eDpyUOkxsn1KE",
-      "description": "Generated test vector #299",
-      "expected": [
-        "book",
-        "muscle",
-        "volcano",
-        "never",
-        "win"
-      ]
-    },
-    {
-      "address": "qzkgiT6IBwRbGRNgDrIAeq6wy442hkJPB9xqe",
-      "description": "Generated test vector #300",
-      "expected": [
-        "question",
-        "zone",
-        "famous",
-        "encrypt",
-        "stellar"
-      ]
-    },
-    {
-      "address": "3hcmsUyxFaGqGsYtpDnPDnkIM1eP1jVD9ekMzM6ZzUctylTxBZn4D6Fz",
-      "description": "Generated test vector #301",
-      "expected": [
-        "upon",
-        "sketch",
-        "paper",
-        "style",
-        "seminar"
-      ]
-    },
-    {
-      "address": "3LrVAbef3jNwyCY4sHut6Fx2QR5LOJDfEvGNpqqrFt44J",
-      "description": "Generated test vector #302",
-      "expected": [
-        "legend",
-        "arrest",
-        "student",
-        "recipe",
-        "rapport"
-      ]
-    },
-    {
-      "address": "osmo1luPrLPlMWXQlQSImCGhSspLNu3YxyS5CvpehxIyeYpE5",
-      "description": "Generated test vector #303",
-      "expected": [
-        "tiny",
-        "virtual",
-        "nest",
-        "elite",
-        "salute"
-      ]
-    },
-    {
-      "address": "FAq8MEgBtihV9cegHhfUAcOdg8SronLU5vobKVk7xHbjJM8",
-      "description": "Generated test vector #304",
-      "expected": [
-        "artwork",
-        "budget",
-        "around",
-        "crisp",
-        "encrypt"
-      ]
-    },
-    {
-      "address": "qzkf0nCkkngotJLxngfSBTxMxHq2EWGtEMZLx",
-      "description": "Generated test vector #305",
-      "expected": [
-        "floor",
-        "tell",
-        "maximum",
-        "steadfast",
-        "important"
-      ]
-    },
-    {
-      "address": "1kznvqS3x27QIOeSbJwbBBABvq4qjnKGGmcxcoRjMIpGpjiB2lzke2",
-      "description": "Generated test vector #306",
-      "expected": [
-        "latin",
-        "leisure",
-        "seed",
-        "felicity",
-        "lush"
-      ]
-    },
-    {
-      "address": "0xrDAkb7LeVqWHWIwlHlWukqYF3ykD0oLwWCCSSkL",
-      "description": "Generated test vector #307",
-      "expected": [
-        "tremendous",
-        "tooth",
-        "shell",
-        "slab",
-        "fearless"
-      ]
-    },
-    {
-      "address": "0x8irGEUIT3COGWJZzp6k1hce90h4xsbEU",
-      "description": "Generated test vector #308",
-      "expected": [
-        "side",
-        "repeat",
-        "ahead",
-        "clean",
-        "satoshi"
-      ]
-    },
-    {
-      "address": "bc1qWUBKViXyi34pySxmi7pjNgxv422esYIc80eutFagUIdFNxBuMvuwX",
-      "description": "Generated test vector #309",
-      "expected": [
-        "game",
-        "height",
-        "dream",
-        "proactive",
-        "kangaroo"
-      ]
-    },
-    {
-      "address": "1VAFPHUF9jZuSTNiVmMrncaizmX2AJ9n9kcTWn4kPhPYvTxD7JH3UNujQS",
-      "description": "Generated test vector #310",
-      "expected": [
-        "ride",
-        "refine",
-        "ginger",
-        "caution",
-        "prize"
-      ]
-    },
-    {
-      "address": "XWpYAq6s89dKXpZI0n7CjgHwUzufkD5et3BYjDb6ho2E7Kz",
-      "description": "Generated test vector #311",
-      "expected": [
-        "soothe",
-        "radio",
-        "brown",
-        "enact",
-        "flower"
-      ]
-    },
-    {
-      "address": "bc1qpXuLK0gfTjA35XRjdDcs0Q4RPfktg9fca5W3ZEqsZeLi",
-      "description": "Generated test vector #312",
-      "expected": [
-        "merit",
-        "brother",
-        "debate",
-        "exultant",
-        "gem"
-      ]
-    },
-    {
-      "address": "qzkjWFEnryukDC7sOYz5X0PnCRcd2j9hSrutoDz5PPTsR3",
-      "description": "Generated test vector #313",
-      "expected": [
-        "alive",
-        "party",
-        "pond",
-        "seek",
-        "tiger"
-      ]
-    },
-    {
-      "address": "0xjleb0plEOyRuiu7At4JRaW7zE9j2oL74SzVNSXxaDZFnuOTFG39",
-      "description": "Generated test vector #314",
-      "expected": [
-        "spice",
-        "print",
-        "popular",
-        "awe",
-        "ankle"
-      ]
-    },
-    {
-      "address": "bc1qVTc7Kr9CrbK7dZzC2J5Znq30YPJyaonYoaceXH36b1TVWVPEJHIW1",
-      "description": "Generated test vector #315",
-      "expected": [
-        "affection",
-        "piano",
-        "laptop",
-        "kiss",
-        "obtain"
-      ]
-    },
-    {
-      "address": "5kOaAupDg5TkspkATwVr9QNejh67eVVqlVuFZHFDMWwfkYHpb4X",
-      "description": "Generated test vector #316",
-      "expected": [
-        "amazing",
-        "spoil",
-        "engrossing",
-        "boom",
-        "employ"
-      ]
-    },
-    {
-      "address": "1kvGQm9UvvyUgFYnlNVUe9oO4EVyNmcCaw",
-      "description": "Generated test vector #317",
-      "expected": [
-        "squeeze",
-        "cream",
-        "light",
-        "between",
-        "under"
-      ]
-    },
-    {
-      "address": "osmo1zZ81f0KIhiE9TvMcZttYs1ds7iqxjvzeGetsb8uS15L0wf",
-      "description": "Generated test vector #318",
-      "expected": [
-        "gorgeous",
-        "name",
-        "artefact",
-        "giraffe",
-        "dry"
-      ]
-    },
-    {
-      "address": "cosmos1thJKedtVU4eS51H4Ogz5t2fuTif6a3cYzgj63pul4RgY",
-      "description": "Generated test vector #319",
-      "expected": [
-        "stock",
-        "pony",
-        "giggle",
-        "expire",
-        "hydra"
-      ]
-    },
-    {
-      "address": "qzkThTYQozQ2JT0EoAMyZsi8zJqM3RpLahKUQJYJ7pS",
-      "description": "Generated test vector #320",
-      "expected": [
-        "praise",
-        "barrel",
-        "unique",
-        "feisty",
-        "harbor"
-      ]
-    },
-    {
-      "address": "bc1qUTQin7JOSZagmiSW1uzOQBmNmv11PE6BpAjWZUGmg",
-      "description": "Generated test vector #321",
-      "expected": [
-        "fine",
-        "address",
-        "gift",
-        "save",
-        "frozen"
-      ]
-    },
-    {
-      "address": "cosmos1rkVDVeCsnm107qDBiWOx9INiqwpg1Gtz",
-      "description": "Generated test vector #322",
-      "expected": [
-        "worth",
-        "sister",
-        "account",
-        "fluent",
-        "hybrid"
-      ]
-    },
-    {
-      "address": "1orYUPIMXGlEGjbVVAvDlTSARqmy0LIfDmpc",
-      "description": "Generated test vector #323",
-      "expected": [
-        "lenient",
-        "portion",
-        "genuine",
-        "spare",
-        "ingenious"
-      ]
-    },
-    {
-      "address": "osmo1Douo7beJizcCHTg9ISnnwcaKhrKBmvohXXHNVcQHORa0Ynz",
-      "description": "Generated test vector #324",
-      "expected": [
-        "half",
-        "cement",
-        "zest",
-        "incredible",
-        "harvest"
-      ]
-    },
-    {
-      "address": "osmo1fK5rAvwCRbgMbrkjTTmmiCPnih4mM2s",
-      "description": "Generated test vector #325",
-      "expected": [
-        "cross",
-        "tourist",
-        "today",
-        "crisp",
-        "figure"
-      ]
-    },
-    {
-      "address": "5QZjxkck0AfjezARkSS2G3K7KuCZKOnBkZBtL5X",
-      "description": "Generated test vector #326",
-      "expected": [
-        "revolution",
-        "ecology",
-        "three",
-        "lyrics",
-        "razor"
-      ]
-    },
-    {
-      "address": "0xzxH52hR3oR6hD4KTiGHoh4FL2oIvHquilA0mXnNG",
-      "description": "Generated test vector #327",
-      "expected": [
-        "bread",
-        "jar",
-        "melt",
-        "essence",
-        "undamaged"
-      ]
-    },
-    {
-      "address": "qzkANeVCQ9ucabPbYbtUYKfl7gWHxWULS9",
-      "description": "Generated test vector #328",
-      "expected": [
-        "flawless",
-        "hotel",
-        "stairs",
-        "noodle",
-        "visit"
-      ]
-    },
-    {
-      "address": "osmo1PXFrsjHjPHrGVjZrMcxcAbLaqpvvwFGzIojqotPwYWxcSMdmz",
-      "description": "Generated test vector #329",
-      "expected": [
-        "impressed",
-        "torch",
-        "camp",
-        "relax",
-        "then"
-      ]
-    },
-    {
-      "address": "MWbMN65ldqchyZhIGaMq1l6E5FxVGdqjeRMskJPTzjpASwSGntWf2Ys8yvU",
-      "description": "Generated test vector #330",
-      "expected": [
-        "patient",
-        "vigor",
-        "shift",
-        "spread",
-        "miracle"
-      ]
-    },
-    {
-      "address": "cosmos1lWSwHll1TPDtX1F7G4bogoRGZ",
-      "description": "Generated test vector #331",
-      "expected": [
-        "brush",
-        "occur",
-        "heart",
-        "sense",
-        "glide"
-      ]
-    },
-    {
-      "address": "cosmos1SiLRPvrN9smn8ZmGK2hTYXfSCC2hc8ofQEiN9czcefUV",
-      "description": "Generated test vector #332",
-      "expected": [
-        "crunch",
-        "eager",
-        "flower",
-        "knife",
-        "proud"
-      ]
-    },
-    {
-      "address": "qzk9f71WSGa4mbYKuzIZGaQuNETZK7442QyLv2eLY1NJgsoGvb",
-      "description": "Generated test vector #333",
-      "expected": [
-        "river",
-        "proactive",
-        "split",
-        "depth",
-        "summer"
-      ]
-    },
-    {
-      "address": "3mYjnLjoruepcUTiH6cwbXo6A7UGfUA0662d2wyLYVxQe6n7VpvdAIBg",
-      "description": "Generated test vector #334",
-      "expected": [
-        "wide",
-        "chat",
-        "method",
-        "guard",
-        "garment"
-      ]
-    },
-    {
-      "address": "qzkVNinGqUcp3aGBmsDPI3icoxSdPBRLcwIRXrla99KkURMMVJxWsILLT",
-      "description": "Generated test vector #335",
-      "expected": [
-        "inestimable",
-        "congress",
-        "fresh",
-        "vivacious",
-        "elan"
-      ]
-    },
-    {
-      "address": "qzk3sHwx7pugbFtM8mkllWYsi8zI6zR9Dyh",
-      "description": "Generated test vector #336",
-      "expected": [
-        "version",
-        "inform",
-        "about",
-        "spatial",
-        "female"
-      ]
-    },
-    {
-      "address": "5NknI9oLuP4O3GOIbYravzP83JAbXWz",
-      "description": "Generated test vector #337",
-      "expected": [
-        "fitness",
-        "segment",
-        "pelican",
-        "history",
-        "unfazed"
-      ]
-    },
-    {
-      "address": "osmo1PAqWxxzeZaDAPQjlGJ8UplqHoXtFMcb7Dna0Ay2ddZVFePYu80ceGLrsL1t",
-      "description": "Generated test vector #338",
-      "expected": [
-        "valor",
-        "nerve",
-        "double",
-        "peerless",
-        "cooperate"
-      ]
-    },
-    {
-      "address": "qzkV1G26NMdwNq3BLyd62TVziibXUEMDxcjRLVqyGHemmo67tSkv7gHe",
-      "description": "Generated test vector #339",
-      "expected": [
-        "nuclear",
-        "yummy",
-        "lucky",
-        "village",
-        "spawn"
-      ]
-    },
-    {
-      "address": "0x03kgLagUoFPiEJvhnePsqd71uiyF8fr9ompgDgiCX",
-      "description": "Generated test vector #340",
-      "expected": [
-        "tobacco",
-        "profit",
-        "album",
-        "liquid",
-        "frozen"
-      ]
-    },
-    {
-      "address": "4eZN23KZglG8kHTETLoAZ2H20kQtboU7bWKSAQ9C",
-      "description": "Generated test vector #341",
-      "expected": [
-        "best",
-        "delectable",
-        "glamorous",
-        "juice",
-        "invulnerable"
-      ]
-    },
-    {
-      "address": "0x1E3GY1aVxiOknvPfy2wWHBgqJTGVk8iJ8U7IHQoMHW17h40X6Qo0A",
-      "description": "Generated test vector #342",
-      "expected": [
-        "heart",
-        "favorite",
-        "power",
-        "zeal",
-        "lemon"
-      ]
-    },
-    {
-      "address": "cosmos18OsL0LIefvMF7UcOf5oHBDH8l5CxeMSPCLEH1JBE0ZiFm9cNtGylMod",
-      "description": "Generated test vector #343",
-      "expected": [
-        "ancient",
-        "rich",
-        "announce",
-        "dextrous",
-        "acquire"
-      ]
-    },
-    {
-      "address": "cosmos1P1UyTuCcPk3kU0qlGCyiZLlp",
-      "description": "Generated test vector #344",
-      "expected": [
-        "drum",
-        "input",
-        "curious",
-        "reaffirm",
-        "vital"
-      ]
-    },
-    {
-      "address": "3T0WZn6H3JgzqQ4lVS5l6y8k6nRvLQg16gSwbOG76IatEQZnmMhPFJ5hDEcGRKqc",
-      "description": "Generated test vector #345",
-      "expected": [
-        "real",
-        "pitch",
-        "wieldy",
-        "meaningful",
-        "caught"
-      ]
-    },
-    {
-      "address": "osmo1yfsgZmnkMnAT6gXBtaM7j1XrVfWkxG9RGILZUa",
-      "description": "Generated test vector #346",
-      "expected": [
-        "question",
-        "crumb",
-        "ardor",
-        "lily",
-        "dial"
-      ]
-    },
-    {
-      "address": "osmo1oFIVy35I4Wz71KzUHr1iRF83rNTAw1W0r",
-      "description": "Generated test vector #347",
-      "expected": [
-        "fond",
-        "party",
-        "ardent",
-        "original",
-        "ghost"
-      ]
-    },
-    {
-      "address": "sMhfQ9b5acjtNK2eoNZ9hutmuDGNATQrrGMxMS",
-      "description": "Generated test vector #348",
-      "expected": [
-        "fuel",
-        "shuffle",
-        "trial",
-        "cloth",
-        "gain"
-      ]
-    },
-    {
-      "address": "37Q6A3WSszUi09R4r6enYRYgiZhL2NMMdT2GzEmIvHVzRPklvCq8IqijJcifY",
-      "description": "Generated test vector #349",
-      "expected": [
-        "crush",
-        "floor",
-        "soft",
-        "glide",
-        "jacket"
-      ]
-    },
-    {
-      "address": "qzk3ITyIlBhDdQmWT5O775ukJJMT27TXOKNoIokORpJ3mItzENT2nY",
-      "description": "Generated test vector #350",
-      "expected": [
-        "usable",
-        "ecstatic",
-        "kiss",
-        "pledge",
-        "merkle"
-      ]
-    },
-    {
-      "address": "cosmos16JqpYWLSlBZ1Blkedp3DGEgE3uJI4pjYUgXyX1",
-      "description": "Generated test vector #351",
-      "expected": [
-        "fiction",
-        "wet",
-        "daughter",
-        "godlike",
-        "apple"
-      ]
-    },
-    {
-      "address": "k2qIL62GFJvnTRxFlNydZU9Vmrs5OY1JgeZknT31bj",
-      "description": "Generated test vector #352",
-      "expected": [
-        "lobster",
-        "cereal",
-        "enchant",
-        "ten",
-        "celery"
-      ]
-    },
-    {
-      "address": "3Pfmr1FdZ4J9fQELhyNThj157zUihVPhxg4cMbivUGBp5Unslxma",
-      "description": "Generated test vector #353",
-      "expected": [
-        "fast",
-        "ameliorate",
-        "inside",
-        "gravity",
-        "promote"
-      ]
-    },
-    {
-      "address": "3OPsGjWkfbIyG51JuiKxbZm09vxXYTa5SJvWKZWoCil5IHyVi0qeUjiDdhM",
-      "description": "Generated test vector #354",
-      "expected": [
-        "reflect",
-        "engage",
-        "gusto",
-        "vital",
-        "brilliance"
-      ]
-    },
-    {
-      "address": "qzkIrkMBSfAKzi1G6gt7j2NaR1cdbw47IVBAWMwKWvr0",
-      "description": "Generated test vector #355",
-      "expected": [
-        "vigor",
-        "affection",
-        "oyster",
-        "privilege",
-        "snappy"
-      ]
-    },
-    {
-      "address": "bc1qDgZpAgIVXFcb4XIgyVfkGHGYPBjbS8RCmcCpCoec1w",
-      "description": "Generated test vector #356",
-      "expected": [
-        "october",
-        "chest",
-        "leaf",
-        "note",
-        "crystal"
-      ]
-    },
-    {
-      "address": "EmyhmbAv1PBRKEmIu9XWLjY65Z3Bjvdoi0bdqzg7MbehBEC",
-      "description": "Generated test vector #357",
-      "expected": [
-        "word",
-        "jar",
-        "beauty",
-        "inspire",
-        "elbow"
-      ]
-    },
-    {
-      "address": "cosmos1bOKH6eSU1Nqap9eWcLFYsZY5y",
-      "description": "Generated test vector #358",
-      "expected": [
-        "orange",
-        "orchard",
-        "brass",
-        "talent",
-        "inherit"
-      ]
-    },
-    {
-      "address": "NOmKQYxIszxgnrdDqoktlT7PKK49BaS4kA9ObCFYHkfdjPbXMf566XoQUJK2W",
-      "description": "Generated test vector #359",
-      "expected": [
-        "name",
-        "salient",
-        "park",
-        "engrossing",
-        "lush"
-      ]
-    },
-    {
-      "address": "qzk3fBbZFKrPbYeHyqHjh62GTo88x5HdbHztPZl",
-      "description": "Generated test vector #360",
-      "expected": [
-        "park",
-        "remunerate",
-        "fan",
-        "wish",
-        "spray"
-      ]
-    },
-    {
-      "address": "bc1qIszVP5FEYqkPIFCUJ95DNqKoh4fKgAEIpEPYInSvWCXXPyscLA",
-      "description": "Generated test vector #361",
-      "expected": [
-        "empathize",
-        "enable",
-        "add",
-        "ladder",
-        "defense"
-      ]
-    },
-    {
-      "address": "cosmos1xpqLbCteaIgi8wVZzHhFJWnHHFM2iqD9UBJAMdsnZKUSwUL",
-      "description": "Generated test vector #362",
-      "expected": [
-        "sibling",
-        "lobster",
-        "play",
-        "faultless",
-        "else"
-      ]
-    },
-    {
-      "address": "3SgnS3v8cpIfuZbk4rsihgtblrbJydUE4UVhqHUNH7T",
-      "description": "Generated test vector #363",
-      "expected": [
-        "bargain",
-        "unrivaled",
-        "permissible",
-        "grid",
-        "empty"
-      ]
-    },
-    {
-      "address": "5ZjqBz0goulyxqAPM4RKRItFJQ1uK8XdhiLl0W9p53chDAToKUIyAp8OgJu",
-      "description": "Generated test vector #364",
-      "expected": [
-        "guess",
-        "arrest",
-        "sort",
-        "brush",
-        "train"
-      ]
-    },
-    {
-      "address": "0xEdKOsiGJlsxx1WTIAEdWqaXtAwUv3JWttnWXbi1wX2W0lzRdyuLo",
-      "description": "Generated test vector #365",
-      "expected": [
-        "occur",
-        "because",
-        "kick",
-        "brush",
-        "rich"
-      ]
-    },
-    {
-      "address": "0xRPjlks7XA2RDyVMygkRgx8F7HGyd",
-      "description": "Generated test vector #366",
-      "expected": [
-        "design",
-        "chest",
-        "wild",
-        "neutral",
-        "state"
-      ]
-    },
-    {
-      "address": "gK8DEImeJ2w535qiSX0NAjgkmpT2vA",
-      "description": "Generated test vector #367",
-      "expected": [
-        "float",
-        "everlasting",
-        "enchant",
-        "major",
-        "cipher"
-      ]
-    },
-    {
-      "address": "5cI8NwqFthIUF2wU6cPAswOujm2g6jSBVMT8QMYfBVVpsNUEb1IxkeDSOd0Lxpcu",
-      "description": "Generated test vector #368",
-      "expected": [
-        "tilt",
-        "candy",
-        "father",
-        "brother",
-        "glamorous"
-      ]
-    },
-    {
-      "address": "bc1qx98uHZq3uosc5RNge2BFFeA9rpPw",
-      "description": "Generated test vector #369",
-      "expected": [
-        "bag",
-        "control",
-        "usable",
-        "mountain",
-        "flavor"
-      ]
-    },
-    {
-      "address": "cosmos1dGY2QDMBWgNO4TtNhH7FpHxMJ9GW2VLs9DRZg0QpoY19H7Skim",
-      "description": "Generated test vector #370",
-      "expected": [
-        "venture",
-        "method",
-        "much",
-        "valor",
-        "silly"
-      ]
-    },
-    {
-      "address": "KkoJg89OEyY6J8GFdJ5khYao3bQxAh4FNPIXDxafsxXr",
-      "description": "Generated test vector #371",
-      "expected": [
-        "wish",
-        "vendor",
-        "ski",
-        "language",
-        "clutch"
-      ]
-    },
-    {
-      "address": "bc1q5ONfFcDAU1Nmt1KZWcmVbZzlwY67KBebQB8PAfaO4sff",
-      "description": "Generated test vector #372",
-      "expected": [
-        "outer",
-        "nimble",
-        "air",
-        "twin",
-        "tunnel"
-      ]
-    },
-    {
-      "address": "bc1qaBuyY4qMcMwImAmIxSJzyCaoAI3JD9OEMwxKlCeCxQob",
-      "description": "Generated test vector #373",
-      "expected": [
-        "snappy",
-        "rise",
-        "year",
-        "family",
-        "oxygen"
-      ]
-    },
-    {
-      "address": "1AR9C7GI2xse0V8J56WwF8hEsfUExleHXNifSy",
-      "description": "Generated test vector #374",
-      "expected": [
-        "reach",
-        "retreat",
-        "peerless",
-        "wave",
-        "cotton"
-      ]
-    },
-    {
-      "address": "3qkLDFedR92Sw4gIQxZcAFaJh1EaJ6dNnRvrdkZr19F5L32rdEO4GjqCf",
-      "description": "Generated test vector #375",
-      "expected": [
-        "nuclear",
-        "shiver",
-        "toe",
-        "parrot",
-        "whale"
-      ]
-    },
-    {
-      "address": "5y55XxDdvIR6fJ8L02gYflf2UoYXdJmceA",
-      "description": "Generated test vector #376",
-      "expected": [
-        "hallmark",
-        "gentle",
-        "this",
-        "stunning",
-        "valley"
-      ]
-    },
-    {
-      "address": "osmo1aD4ZO2JtSRoOXGzIn1vKrDhZf",
-      "description": "Generated test vector #377",
-      "expected": [
-        "eloquence",
-        "alive",
-        "frequent",
-        "win",
-        "utility"
-      ]
-    },
-    {
-      "address": "8mtHnVVcujWPzQe3n2XwpVZu4Ad18AUBKnSpsHm",
-      "description": "Generated test vector #378",
-      "expected": [
-        "resilient",
-        "faculty",
-        "dose",
-        "about",
-        "document"
-      ]
-    },
-    {
-      "address": "cosmos1to5XN0zicuBBrdwMvwymlZKHuVgERTPL3g",
-      "description": "Generated test vector #379",
-      "expected": [
-        "iron",
-        "large",
-        "element",
-        "double",
-        "stand"
-      ]
-    },
-    {
-      "address": "1CFyLQiXRByQkNzM5t5q6Q93Pl3W3w7a1VRd",
-      "description": "Generated test vector #380",
-      "expected": [
-        "irreplaceable",
-        "phone",
-        "eager",
-        "horse",
-        "artist"
-      ]
-    },
-    {
-      "address": "osmo1u154vXQKB3vBcZgBliKdvUPN4PZc8rQn",
-      "description": "Generated test vector #381",
-      "expected": [
-        "firm",
-        "order",
-        "rural",
-        "update",
-        "forward"
-      ]
-    },
-    {
-      "address": "cosmos1m3hrhbncL8resMfnO2MkHvU",
-      "description": "Generated test vector #382",
-      "expected": [
-        "invite",
-        "keep",
-        "service",
-        "any",
-        "focus"
-      ]
-    },
-    {
-      "address": "osmo1jwed7JJNyA4ZdHSDcRoDqQS7PJrK7xnaEx0junNZenxp3l",
-      "description": "Generated test vector #383",
-      "expected": [
-        "sister",
-        "cure",
-        "fluent",
-        "orange",
-        "dynamic"
-      ]
-    },
-    {
-      "address": "1Hldl6RjWt1eTbc3APwaVH4Fpj3fyni5rQ75CU9I8B11fKKAkc7oP2X2iwG",
-      "description": "Generated test vector #384",
-      "expected": [
-        "apple",
-        "blade",
-        "sudden",
-        "profit",
-        "youth"
-      ]
-    },
-    {
-      "address": "1CCbKaBfvkSIlA7gXSkv4WG4SQJAVFnxIfKtUQDRfIcd9v",
-      "description": "Generated test vector #385",
-      "expected": [
-        "ride",
-        "alley",
-        "luggage",
-        "layer",
-        "rejoice"
-      ]
-    },
-    {
-      "address": "bc1qHYLnHx6FK3Xr7tdfFkUkdIMHMZoPjprErniUGgA7wLmahMacmd6RniSE",
-      "description": "Generated test vector #386",
-      "expected": [
-        "savings",
-        "relax",
-        "repair",
-        "crush",
-        "bench"
-      ]
-    },
-    {
-      "address": "3pScWifucpmQZvXoZCw3fHiebkLz2QUDxL1j",
-      "description": "Generated test vector #387",
-      "expected": [
-        "nautilus",
-        "give",
-        "balance",
-        "prefer",
-        "valid"
-      ]
-    },
-    {
-      "address": "hWq0TYeykJXmhEFwIw004CU3xR5fFywsrVpOBA8QLln",
-      "description": "Generated test vector #388",
-      "expected": [
-        "inestimable",
-        "mightily",
-        "gospel",
-        "meaningful",
-        "auspicious"
-      ]
-    },
-    {
-      "address": "5aOxCiki2hsjnziZvORqjQ0N7HE96MT5jotYfLQqmvoi7968lwdG",
-      "description": "Generated test vector #389",
-      "expected": [
-        "agree",
-        "unreal",
-        "equip",
-        "patriot",
-        "fire"
-      ]
-    },
-    {
-      "address": "bc1qqmYYoeZ0GzxSwCT4IquCK3XqV3N6wowD1y5KF7dmr",
-      "description": "Generated test vector #390",
-      "expected": [
-        "later",
-        "situate",
-        "piece",
-        "aware",
-        "health"
-      ]
-    },
-    {
-      "address": "1vwH4J564sfvVKu6Jy0l0oC8iwS9qx5r97OKp36Ys",
-      "description": "Generated test vector #391",
-      "expected": [
-        "candy",
-        "jelly",
-        "program",
-        "embrace",
-        "junior"
-      ]
-    },
-    {
-      "address": "osmo1nYCzOCg44bOTEGwk5eTB4ItmYOTk3FCqQ3Egm715PQzv",
-      "description": "Generated test vector #392",
-      "expected": [
-        "surround",
-        "enjoy",
-        "gusto",
-        "inside",
-        "prosper"
-      ]
-    },
-    {
-      "address": "34CiAQzmardZ5NwjBHb6uG9c5DQTelC0mALoJXVnyXRE",
-      "description": "Generated test vector #393",
-      "expected": [
-        "horn",
-        "below",
-        "melt",
-        "index",
-        "genuine"
-      ]
-    },
-    {
-      "address": "3mmMvjWkSLlT1WvS7v3OnokNVBRlGLaw",
-      "description": "Generated test vector #394",
-      "expected": [
-        "share",
-        "haunting",
-        "cabin",
-        "glide",
-        "image"
-      ]
-    },
-    {
-      "address": "qzkWnoAF8Dfd8clLWhFj0xgEjgN78n7QNlf1P0ARq1WD",
-      "description": "Generated test vector #395",
-      "expected": [
-        "nothing",
-        "mango",
-        "badge",
-        "blossom",
-        "pudding"
-      ]
-    },
-    {
-      "address": "osmo1Uin8nQj75FNUs9v91JSPQ1l7zxYM9nO3p3XDXeOGqQEgoEt16VOua",
-      "description": "Generated test vector #396",
-      "expected": [
-        "state",
-        "punctual",
-        "pupil",
-        "recall",
-        "wealth"
-      ]
-    },
-    {
-      "address": "1WkOFryJSOxtrDwpekMef8qeVPuqJPJx9KBEXdXYbk8P",
-      "description": "Generated test vector #397",
-      "expected": [
-        "artefact",
-        "hip",
-        "permissible",
-        "innocent",
-        "reform"
-      ]
-    },
-    {
-      "address": "1fTft6JUA6zGOzJGnkEEeLViOPb7R7HDHv066Q3RthfVul7PWNlhche0WEx9I",
-      "description": "Generated test vector #398",
-      "expected": [
-        "chief",
-        "course",
-        "curious",
-        "wrap",
-        "begin"
-      ]
-    },
-    {
-      "address": "qzkDSaAIytPAyJK52fYxvQc1czvRDcT8JM7BgNOiRnmRKSlv",
-      "description": "Generated test vector #399",
-      "expected": [
-        "happy",
-        "beetle",
-        "flavor",
-        "immense",
-        "health"
-      ]
-    },
-    {
-      "address": "3jzms90M4MIJuy5zAsuq35Utpe3Ly5KUpR1rBo22qGPOIjcuALD59PHVG1qpga3",
-      "description": "Generated test vector #400",
-      "expected": [
-        "divine",
-        "awake",
-        "wave",
-        "become",
-        "cactus"
-      ]
-    },
-    {
-      "address": "qzkdk1VDs0vrSzuXiWcasJ0xdSndb32gWm1uyw",
-      "description": "Generated test vector #401",
-      "expected": [
-        "water",
-        "idyllic",
-        "tomorrow",
-        "dial",
-        "envelope"
-      ]
-    },
-    {
-      "address": "5uuQDa68eJneRIlRyne5Icm3lz5TcptsqmgsPSzTPO",
-      "description": "Generated test vector #402",
-      "expected": [
-        "gadget",
-        "pattern",
-        "proactive",
-        "slot",
-        "online"
-      ]
-    },
-    {
-      "address": "cX9OS3JrU7jXfPE3dq9s0doXZ6kYLry",
-      "description": "Generated test vector #403",
-      "expected": [
-        "purse",
-        "similar",
-        "cheese",
-        "group",
-        "frame"
-      ]
-    },
-    {
-      "address": "3UTUVmi9Moiiy9n2onpDeQPAC5a1iDLUt3drwd6koKVYkbq4XcHC6XYX4b",
-      "description": "Generated test vector #404",
-      "expected": [
-        "shop",
-        "brand",
-        "stand",
-        "impact",
-        "youth"
-      ]
-    },
-    {
-      "address": "qzk7PidxB2zZOHT7ZDNEZzMZ6lqxNo2BWDjF5ltc",
-      "description": "Generated test vector #405",
-      "expected": [
-        "backed",
-        "brush",
-        "rich",
-        "view",
-        "significant"
-      ]
-    },
-    {
-      "address": "osmo1yHS4SjpplJ6Xgf8hCFovQz4MP33CdZscNnjg8MRlt2VEkiEyp",
-      "description": "Generated test vector #406",
-      "expected": [
-        "revolution",
-        "razor",
-        "pupil",
-        "large",
-        "reform"
-      ]
-    },
-    {
-      "address": "bc1qlb1jhkQQq2x74TaHm8sB4bFGFJuqbk1MxFvL2lQEM4yNm6Ltol5DXjw",
-      "description": "Generated test vector #407",
-      "expected": [
-        "image",
-        "wheel",
-        "embrace",
-        "pave",
-        "street"
-      ]
-    },
-    {
-      "address": "3z2vfYiOJ5jre57VnjtURyBCSjzZSP7",
-      "description": "Generated test vector #408",
-      "expected": [
-        "estate",
-        "expand",
-        "version",
-        "immortal",
-        "reflect"
-      ]
-    },
-    {
-      "address": "0xxuqFOIgmgOVcqH0RjYf0fZWxsP2SH1HH9saVguIdtsiZaXl54ENDZGW",
-      "description": "Generated test vector #409",
-      "expected": [
-        "basket",
-        "believe",
-        "tail",
-        "guide",
-        "screen"
-      ]
-    },
-    {
-      "address": "5r1UWhAislLSBielsdrLGXgT64J11f1BZzL8rQfjRgId2AbQkaa6UHl",
-      "description": "Generated test vector #410",
-      "expected": [
-        "catalog",
-        "orbit",
-        "border",
-        "fish",
-        "meticulous"
-      ]
-    },
-    {
-      "address": "52aNulpGoS5IkzYkWVdBHAZU51kI32F3P2mYzUFN27",
-      "description": "Generated test vector #411",
-      "expected": [
-        "crawl",
-        "neutral",
-        "extend",
-        "fetch",
-        "actor"
-      ]
-    },
-    {
-      "address": "5ygAsWaejFj3SjP0Tn3CL1Gu6TRz3EfcUSZkN5G1Y",
-      "description": "Generated test vector #412",
-      "expected": [
-        "mist",
-        "stem",
-        "lit",
-        "diligent",
-        "expect"
-      ]
-    },
-    {
-      "address": "bc1qMCBzCFg8z0NHsOlP9Yjyw7yxk1Jfum",
-      "description": "Generated test vector #413",
-      "expected": [
-        "reason",
-        "hair",
-        "dextrous",
-        "goddess",
-        "company"
-      ]
-    },
-    {
-      "address": "vnqANVT2JLBMiMA9sVJybaWCQEIQ0rr7lLFszp0G",
-      "description": "Generated test vector #414",
-      "expected": [
-        "poem",
-        "urban",
-        "crop",
-        "hug",
-        "reveal"
-      ]
-    },
-    {
-      "address": "osmo1yKYgxWHqtXkNX2ukZ9kiCyrLd0lHpGVa2JlPcD",
-      "description": "Generated test vector #415",
-      "expected": [
-        "proactive",
-        "donor",
-        "enough",
-        "walnut",
-        "calm"
-      ]
-    },
-    {
-      "address": "MTq09Iz1a5BwaacvyQg3Wwm46ygqJZ8P3sBdV44OGk2Xb",
-      "description": "Generated test vector #416",
-      "expected": [
-        "segment",
-        "peace",
-        "liking",
-        "doctor",
-        "inhale"
-      ]
-    },
-    {
-      "address": "bc1qxQcqs6pL6yrvA3y4k6xWhuvL2i5Vl1hao5OsXqt3srWxnBk0YHtEf",
-      "description": "Generated test vector #417",
-      "expected": [
-        "tattoo",
-        "embark",
-        "oven",
-        "green",
-        "swing"
-      ]
-    },
-    {
-      "address": "3uvgR1Kaphlf15WoWi8EAqNTMIStulPk0i1ghFEMBd4GNwLq",
-      "description": "Generated test vector #418",
-      "expected": [
-        "path",
-        "between",
-        "butter",
-        "extend",
-        "term"
-      ]
-    },
-    {
-      "address": "qzkqownVs2T0sZ0hJR8Cq0LcoFbmGA2emZGLl6FF3YIvkHmrI",
-      "description": "Generated test vector #419",
-      "expected": [
-        "arrive",
-        "chime",
-        "moral",
-        "hill",
-        "jeans"
-      ]
-    },
-    {
-      "address": "3QthQzZnuoYWdF1wQlrxfDU5Ky59nYiLpxXq4dKKbccKvob4ZQ",
-      "description": "Generated test vector #420",
-      "expected": [
-        "three",
-        "spell",
-        "heart",
-        "remember",
-        "series"
-      ]
-    },
-    {
-      "address": "osmo1ffKPsrOyTFGM60MCwk4wWENJUhGgKleUCHO",
-      "description": "Generated test vector #421",
-      "expected": [
-        "clock",
-        "purity",
-        "enable",
-        "impact",
-        "lake"
-      ]
-    },
-    {
-      "address": "1sHN4CfauJs75YWXmE2GyGfTNnFU0hfp9EHr4J",
-      "description": "Generated test vector #422",
-      "expected": [
-        "ladder",
-        "kidney",
-        "orchard",
-        "pulse",
-        "fish"
-      ]
-    },
-    {
-      "address": "0xZBJwj15KnWfZtFUUCUVPmPbUhoKa7H09tOthSc",
-      "description": "Generated test vector #423",
-      "expected": [
-        "important",
-        "wire",
-        "haunting",
-        "cozy",
-        "flawless"
-      ]
-    },
-    {
-      "address": "0xuHgFhrdinCy45XGmUiBnvSypvXdaut2U8fNsPfuxxKJwWhxp7MOZ4DlbjK9Oz",
-      "description": "Generated test vector #424",
-      "expected": [
-        "brick",
-        "hash",
-        "share",
-        "ledger",
-        "wide"
-      ]
-    },
-    {
-      "address": "osmo1sGxpeRzcg9C6NmHY4zq87cPHi8aiAA5FgNPCGJKX",
-      "description": "Generated test vector #425",
-      "expected": [
-        "actual",
-        "glisten",
-        "promote",
-        "influential",
-        "text"
-      ]
-    },
-    {
-      "address": "0xJcEqU41MQakFVrMCqt7gRZVH3iEC3b8X79WU0YWVcsmFGeEHBU7noz",
-      "description": "Generated test vector #426",
-      "expected": [
-        "blade",
-        "achieve",
-        "myself",
-        "advance",
-        "vacuum"
-      ]
-    },
-    {
-      "address": "qzkapoaa46vFNzbHyvW85e01ofcOBiqrbREKRgnq9oIeMSt75ir7bTIjyp",
-      "description": "Generated test vector #427",
-      "expected": [
-        "promote",
-        "meaningful",
-        "topple",
-        "provide",
-        "venture"
-      ]
-    },
-    {
-      "address": "5lx90XlaZRPkgHMcsGgxdaHBOd5WbuXyXSewzHbvDtd",
-      "description": "Generated test vector #428",
-      "expected": [
-        "loving",
-        "face",
-        "state",
-        "gorgeous",
-        "analyst"
-      ]
-    },
-    {
-      "address": "qzki7IaXnClWOkfmYJUDeyihXp1SrzgEJH9eZCsz8ins1",
-      "description": "Generated test vector #429",
-      "expected": [
-        "pinnacle",
-        "invaluable",
-        "stimulate",
-        "vigilant",
-        "effort"
-      ]
-    },
-    {
-      "address": "3wfyil4qf74PbqTB02xbPAMtnizOLsI8PqvQKvxig",
-      "description": "Generated test vector #430",
-      "expected": [
-        "reform",
-        "senior",
-        "nominee",
-        "blessing",
-        "exalt"
-      ]
-    },
-    {
-      "address": "17H5fXHzUrLHzDA28PhC94FqCbUBO88gcs0iBczTV5V6mLThmu",
-      "description": "Generated test vector #431",
-      "expected": [
-        "near",
-        "depend",
-        "ardent",
-        "inherit",
-        "cloth"
-      ]
-    },
-    {
-      "address": "bc1qHFq6cjn7zrlSaekUE6ja3amndbGpsSzogaGJW9hhXb7",
-      "description": "Generated test vector #432",
-      "expected": [
-        "hope",
-        "unrivaled",
-        "hash",
-        "stand",
-        "thumb"
-      ]
-    },
-    {
-      "address": "1JTjoQmCZP6JCScaXuH0f04A9ycbK0KrnA3SpB5GffLORuiJXjbNXP",
-      "description": "Generated test vector #433",
-      "expected": [
-        "furnace",
-        "night",
-        "valid",
-        "flexible",
-        "save"
-      ]
-    },
-    {
-      "address": "1mVrzBxJLr3qzBSfIqNaiV4QjinB5ra7ycv3EQ4CWw8zj5vCafM9I",
-      "description": "Generated test vector #434",
-      "expected": [
-        "urban",
-        "blur",
-        "redeemed",
-        "celebrate",
-        "lunar"
-      ]
-    },
-    {
-      "address": "3ghzekNuIr1y2dLnqzdhpiff24m4J9Mefb46SaTAu7VT8qxc2O3",
-      "description": "Generated test vector #435",
-      "expected": [
-        "umbrella",
-        "chalk",
-        "fence",
-        "exhibit",
-        "joyous"
-      ]
-    },
-    {
-      "address": "qzk90sZbMuaEUMmTEjoIAEzk6UUhC7y9F0RyvRyji87MB90B1qMDZPJN",
-      "description": "Generated test vector #436",
-      "expected": [
-        "birth",
-        "vintage",
-        "clutch",
-        "royal",
-        "darling"
-      ]
-    },
-    {
-      "address": "osmo1c8gFFDsjo1YttzTxjgfXApTww",
-      "description": "Generated test vector #437",
-      "expected": [
-        "salmon",
-        "climb",
-        "tenant",
-        "notice",
-        "yellow"
-      ]
-    },
-    {
-      "address": "38OrrYVgSEmIGCaPonPWF1XSGrXH9z1",
-      "description": "Generated test vector #438",
-      "expected": [
-        "avocado",
-        "puzzle",
-        "mixture",
-        "october",
-        "eagle"
-      ]
-    },
-    {
-      "address": "0x0Y9lj2tOrXl1hytUGa6EgT2x9mdRgBZM4dfr6n4DhgQUKCOzWg",
-      "description": "Generated test vector #439",
-      "expected": [
-        "effective",
-        "network",
-        "aim",
-        "educate",
-        "galore"
-      ]
-    },
-    {
-      "address": "5V6QMUdFgO0NYuwahmBnGRb5IPZGaiDVSD6gbQg",
-      "description": "Generated test vector #440",
-      "expected": [
-        "floor",
-        "hoping",
-        "interest",
-        "else",
-        "poem"
-      ]
-    },
-    {
-      "address": "qzkimKVNxDWHEZc2Ig3lraSIWC8bkp1mVnyl8hK",
-      "description": "Generated test vector #441",
-      "expected": [
-        "rapport",
-        "key",
-        "goat",
-        "adapt",
-        "zebra"
-      ]
-    },
-    {
-      "address": "5I0qPbXQwBQp04wU2itT03Zya5nw87OV3j0RRM1Jr1Fna4TLYYtojw",
-      "description": "Generated test vector #442",
-      "expected": [
-        "hand",
-        "act",
-        "favorite",
-        "lemon",
-        "skate"
-      ]
-    },
-    {
-      "address": "1DwYIysSpP61oIfuY2rEq9EYKA7tpuU4gHeBEYiKVEgwj0NVYCoxjW",
-      "description": "Generated test vector #443",
-      "expected": [
-        "significant",
-        "promote",
-        "apple",
-        "project",
-        "balcony"
-      ]
-    },
-    {
-      "address": "5VACiwBbmZCwXUD9UDSnEtoalBY0FuCldIuVyG83lGsczpaOxmDeZ",
-      "description": "Generated test vector #444",
-      "expected": [
-        "february",
-        "next",
-        "annual",
-        "fresh",
-        "stone"
-      ]
-    },
-    {
-      "address": "bc1qmI5DQwh3AFDd3RXG69KoduwoaWQ6Limzf4KB6WtQTzdDKCS",
-      "description": "Generated test vector #445",
-      "expected": [
-        "castle",
-        "because",
-        "quantum",
-        "rotate",
-        "always"
-      ]
-    },
-    {
-      "address": "osmo1j0K1oWq0D1UiTlRkNDgeCx2AhEAdsMHhqIJox6Z7a",
-      "description": "Generated test vector #446",
-      "expected": [
-        "supreme",
-        "young",
-        "aunt",
-        "success",
-        "regular"
-      ]
-    },
-    {
-      "address": "3blz7JIf8qQqZdH1B2V5Xe5BW3Q6smlZl4xnhYjrB",
-      "description": "Generated test vector #447",
-      "expected": [
-        "barn",
-        "public",
-        "seek",
-        "boy",
-        "fulfill"
-      ]
-    },
-    {
-      "address": "bc1qH7cy5qjvTYIgLTnCjVl1jJYnOs",
-      "description": "Generated test vector #448",
-      "expected": [
-        "picture",
-        "entry",
-        "chuckle",
-        "clarify",
-        "result"
-      ]
-    },
-    {
-      "address": "5hAAyuk1Is8KqUKbSFHsaU9U0bcaSg70K",
-      "description": "Generated test vector #449",
-      "expected": [
-        "thing",
-        "mind",
-        "alter",
-        "canoe",
-        "priceless"
-      ]
-    },
-    {
-      "address": "3V4W62ocqJcn3vlmakwcY4Xv8h2ouuS3ozFIIRmmW",
-      "description": "Generated test vector #450",
-      "expected": [
-        "text",
-        "ticket",
-        "rely",
-        "truly",
-        "angel"
-      ]
-    },
-    {
-      "address": "bc1qsp4KiYbIT9oh7qqkJBuLt2Lidi7yeCKrealW",
-      "description": "Generated test vector #451",
-      "expected": [
-        "spend",
-        "furnace",
-        "jellyfish",
-        "ask",
-        "ethics"
-      ]
-    },
-    {
-      "address": "cosmos1J3v9giyeoDoy61qtPF4pg4R3ABVb",
-      "description": "Generated test vector #452",
-      "expected": [
-        "install",
-        "light",
-        "cabin",
-        "ultra",
-        "market"
-      ]
-    },
-    {
-      "address": "33tidkgvouafnVgNsPd0EKNqLhQpi8FoYMPRHgl5aVDcExJ72UK9Af26kCHrAdGN",
-      "description": "Generated test vector #453",
-      "expected": [
-        "news",
-        "present",
-        "divine",
-        "dream",
-        "vacuum"
-      ]
-    },
-    {
-      "address": "osmo1GZH8tBXiWbFyhKksnW2TeKkjlvUHvX5zU9BIlV2Of6XpqrJKWLOyZBiyqZ",
-      "description": "Generated test vector #454",
-      "expected": [
-        "position",
-        "essence",
-        "what",
-        "lion",
-        "warm"
-      ]
-    },
-    {
-      "address": "osmo17wmeZOboeTfnwmMisCfKxac75iEc",
-      "description": "Generated test vector #455",
-      "expected": [
-        "striking",
-        "phenomenal",
-        "lava",
-        "business",
-        "prize"
-      ]
-    },
-    {
-      "address": "5y5UZd81ynG6aJokqfZO1Pm1mza6MrfAimgv3r4mlD3GDA4",
-      "description": "Generated test vector #456",
-      "expected": [
-        "latin",
-        "canyon",
-        "invest",
-        "laptop",
-        "grand"
-      ]
-    },
-    {
-      "address": "0x1mpsMcrAeuvFB9ZEMlsl2rntVeEnvWXFypJ9k2Vwn0iIcQkFTqO8avF",
-      "description": "Generated test vector #457",
-      "expected": [
-        "hug",
-        "social",
-        "funny",
-        "animal",
-        "spice"
-      ]
-    },
-    {
-      "address": "osmo1D6kyrtKaXKnHqAs0NTsC7GrCyxHBO12pzCQyoIY7eO2fx",
-      "description": "Generated test vector #458",
-      "expected": [
-        "clever",
-        "clarify",
-        "review",
-        "pair",
-        "flex"
-      ]
-    },
-    {
-      "address": "6jDRJgWtcC0Ib8wUAucRB4KpbDBnYDX4",
-      "description": "Generated test vector #459",
-      "expected": [
-        "grid",
-        "bronze",
-        "between",
-        "angel",
-        "item"
-      ]
-    },
-    {
-      "address": "llz14NWMVCOAnVPYcDmzsYRR1FDyTt9ubPsiZR",
-      "description": "Generated test vector #460",
-      "expected": [
-        "label",
-        "vehicle",
-        "stone",
-        "shuffle",
-        "epoch"
-      ]
-    },
-    {
-      "address": "0xOIVVHySbyldeVJ73alYKVFMPJHjhjR7VVofT5HYtqzsb",
-      "description": "Generated test vector #461",
-      "expected": [
-        "bonus",
-        "glass",
-        "keypair",
-        "rocket",
-        "twenty"
-      ]
-    },
-    {
-      "address": "8fV7s9LbrWLzbxlMYBaqLk9o4UrWYRWRYeSgD1aN7qnh2",
-      "description": "Generated test vector #462",
-      "expected": [
-        "flying",
-        "emerge",
-        "divine",
-        "wool",
-        "uncover"
-      ]
-    },
-    {
-      "address": "gOpV5O3Ofa6WhdLjNc2mFHG37ejjk6IOV",
-      "description": "Generated test vector #463",
-      "expected": [
-        "hair",
-        "advocate",
-        "bachelor",
-        "humility",
-        "triumph"
-      ]
-    },
-    {
-      "address": "cosmos1u6ObjFJvJNCreHAKgL31kDyacibMCNX9AP2rnXxONuGYEalTsPOsOxzb",
-      "description": "Generated test vector #464",
-      "expected": [
-        "mouse",
-        "already",
-        "vigor",
-        "fantasy",
-        "sugar"
-      ]
-    },
-    {
-      "address": "17Cpl4JzYRpxVa4sxiVQcwRAFeHBw6Q82Zq2Fjv",
-      "description": "Generated test vector #465",
-      "expected": [
-        "tender",
-        "bench",
-        "unrivaled",
-        "receive",
-        "talent"
-      ]
-    },
-    {
-      "address": "qzkpw6yjmhAxYLMGrextY81PkU6lGl7Ihxy76JzlvLK3LYKTXTptID8ICELxW",
-      "description": "Generated test vector #466",
-      "expected": [
-        "extra",
-        "impact",
-        "churn",
-        "invulnerable",
-        "west"
-      ]
-    },
-    {
-      "address": "0xhpkG1pLpuLU8LjhaaesOOCy0S67sOocr6esbGJt30DcLAuP",
-      "description": "Generated test vector #467",
-      "expected": [
-        "clog",
-        "change",
-        "equip",
-        "arrange",
-        "pitch"
-      ]
-    },
-    {
-      "address": "cosmos1UPRsaMRjGoZb59A6g6IMh66ZH8YO1yiaD",
-      "description": "Generated test vector #468",
-      "expected": [
-        "fabulous",
-        "swim",
-        "godsend",
-        "vast",
-        "heart"
-      ]
-    },
-    {
-      "address": "osmo1MaMz6AuDUOT7s0tXtpSt7ODM0gdEmkE8dzUVlcRZ",
-      "description": "Generated test vector #469",
-      "expected": [
-        "turn",
-        "season",
-        "bench",
-        "jovial",
-        "coil"
-      ]
-    },
-    {
-      "address": "1FlClTY0t0rLWEbUH1Wte8aZzeUeDc4IWwDoO1Kevl",
-      "description": "Generated test vector #470",
-      "expected": [
-        "captain",
-        "piece",
-        "under",
-        "phrase",
-        "bus"
-      ]
-    },
-    {
-      "address": "cosmos1LeXFvHeTf3CqXywLhyOYarK3X",
-      "description": "Generated test vector #471",
-      "expected": [
-        "couple",
-        "creek",
-        "lawsuit",
-        "superb",
-        "mesmerize"
-      ]
-    },
-    {
-      "address": "cosmos13hrbVLWHlXbmxVVTcF4Hy6MQbBHjtLu8xQRmmoSidl9",
-      "description": "Generated test vector #472",
-      "expected": [
-        "liking",
-        "sunset",
-        "change",
-        "airport",
-        "almost"
-      ]
-    },
-    {
-      "address": "cosmos10FFdVAcSLD8KcQhRf0YN81em1jyguruckylhKzs",
-      "description": "Generated test vector #473",
-      "expected": [
-        "cooperate",
-        "sentence",
-        "gripping",
-        "planet",
-        "angel"
-      ]
-    },
-    {
-      "address": "qzkjtLDaDqSsT7dG3V43eUrUZJTJAXX9izpRJ5w8",
-      "description": "Generated test vector #474",
-      "expected": [
-        "include",
-        "consider",
-        "efficient",
-        "neutral",
-        "celery"
-      ]
-    },
-    {
-      "address": "3eHbxY4a4Gd5doyoZwiGNOAZMKanchkXobwbqjm6UJRw1JZ8cMHc1C",
-      "description": "Generated test vector #475",
-      "expected": [
-        "notice",
-        "twice",
-        "donkey",
-        "occur",
-        "document"
-      ]
-    },
-    {
-      "address": "qzkPpqN7crILQ5nfINhHyNGr0ru8jkXxhMdRxoYgAiHbaBNU",
-      "description": "Generated test vector #476",
-      "expected": [
-        "weather",
-        "phenomenal",
-        "stage",
-        "machine",
-        "buyer"
-      ]
-    },
-    {
-      "address": "5iv9wwe7QeoT6AYtdGJxlsmKtJdxqUn",
-      "description": "Generated test vector #477",
-      "expected": [
-        "toe",
-        "raise",
-        "sense",
-        "raccoon",
-        "refine"
-      ]
-    },
-    {
-      "address": "osmo1KtCJTV5NGAUsSKAyho2SEMIy7xDV89R0Xfq1XglbwEn0iRRnQn9zql",
-      "description": "Generated test vector #478",
-      "expected": [
-        "bridge",
-        "foam",
-        "node",
-        "exhibit",
-        "fond"
-      ]
-    },
-    {
-      "address": "tVY53CMKlkDo5jS1OcolJp9eMoXGsnsOLG3aPu",
-      "description": "Generated test vector #479",
-      "expected": [
-        "clean",
-        "bullish",
-        "know",
-        "spend",
-        "dinner"
-      ]
-    },
-    {
-      "address": "osmo1uqv3d5uJLeInbSyrpPlV9SjhBCme2F",
-      "description": "Generated test vector #480",
-      "expected": [
-        "mango",
-        "panoramic",
-        "squirrel",
-        "drink",
-        "scale"
-      ]
-    },
-    {
-      "address": "0xysD5BmwoXutMXirTcDRTiEbOAWwkCiJa5ZacRlF8NX62X6TrBtEKg",
-      "description": "Generated test vector #481",
-      "expected": [
-        "gym",
-        "novel",
-        "toward",
-        "remain",
-        "monkey"
-      ]
-    },
-    {
-      "address": "bc1qUZR0LeLRAKMtt1LXmZWBninK3ggSK5HOO4ur5obRlBT92ilKG46sZ5kyC",
-      "description": "Generated test vector #482",
-      "expected": [
-        "chest",
-        "cinnamon",
-        "divine",
-        "god",
-        "time"
-      ]
-    },
-    {
-      "address": "dFFi7mGHDuH0eGxeTRpNyC8L88yUuABqWx2H811BmXdHJifyazwtBF6uPGyuV",
-      "description": "Generated test vector #483",
-      "expected": [
-        "excellent",
-        "immaculate",
-        "sleep",
-        "soccer",
-        "tomato"
-      ]
-    },
-    {
-      "address": "qzkg7pAadGuWzGiQwzvuj31qVKDsi0mG49bWZY1TC7zcMYq4FzkX",
-      "description": "Generated test vector #484",
-      "expected": [
-        "lunch",
-        "pattern",
-        "feel",
-        "elite",
-        "coast"
-      ]
-    },
-    {
-      "address": "osmo1HTn8WreqJKAeLK1432iq9IgwLGs4",
-      "description": "Generated test vector #485",
-      "expected": [
-        "explain",
-        "degree",
-        "ardent",
-        "reaffirm",
-        "replace"
-      ]
-    },
-    {
-      "address": "qzkvVUE98atN7JP3KMIi8aSpj21X8vG8iGL2D0joIBC",
-      "description": "Generated test vector #486",
-      "expected": [
-        "supreme",
-        "sovereign",
-        "won",
-        "theory",
-        "gold"
-      ]
-    },
-    {
-      "address": "cosmos1Bww6Oe3T9QSmFUiLWGyF6gApVk3bNSxMrCZsGg8lay0n74ffY5XfHjW2Z",
-      "description": "Generated test vector #487",
-      "expected": [
-        "breeze",
-        "inside",
-        "opulent",
-        "father",
-        "alarm"
-      ]
-    },
-    {
-      "address": "osmo1zIZ55oCiOhM6bjkDZdRX8tqXHNd3rCBuqMBEtKeY1HQ0",
-      "description": "Generated test vector #488",
-      "expected": [
-        "coin",
-        "display",
-        "congress",
-        "spoil",
-        "broom"
-      ]
-    },
-    {
-      "address": "bc1qFveEdKw9VMkZnqFzG17QyjKQl6WLNuf2HjJWGxOVFiYOE4yV7chCiDj",
-      "description": "Generated test vector #489",
-      "expected": [
-        "flame",
-        "flamingo",
-        "wombat",
-        "crisp",
-        "sage"
-      ]
-    },
-    {
-      "address": "yLorRP0PLCcScECM1W19lvBXBTV0O2guNQVB4wN",
-      "description": "Generated test vector #490",
-      "expected": [
-        "good",
-        "rapport",
-        "awake",
-        "then",
-        "buzz"
-      ]
-    },
-    {
-      "address": "MPTGSrcwFm8ttDd5gjoOudy9hMy5HecN2BBd2o8XMwFq8Js49YA17YenitnE",
-      "description": "Generated test vector #491",
-      "expected": [
-        "beam",
-        "uncle",
-        "entice",
-        "devote",
-        "whale"
-      ]
-    },
-    {
-      "address": "bc1qw6wRj4PPoF7VmcJfI5PN9okf0TevTHKXb",
-      "description": "Generated test vector #492",
-      "expected": [
-        "river",
-        "theme",
-        "pencil",
-        "harbor",
-        "service"
-      ]
-    },
-    {
-      "address": "qzksX0RyTvNwrfMq55hdaakkFfJeZr9oVZPx3RpIRYr",
-      "description": "Generated test vector #493",
-      "expected": [
-        "mountain",
-        "item",
-        "food",
-        "profit",
-        "shine"
-      ]
-    },
-    {
-      "address": "3HrNom5YA0v5bTKRlIlxCLxzBeityok6bXZiRn",
-      "description": "Generated test vector #494",
-      "expected": [
-        "soon",
-        "cooperate",
-        "major",
-        "bachelor",
-        "drop"
-      ]
-    },
-    {
-      "address": "e9S8I3EMbDCejsYhsMnWvC04At1xdIpU",
-      "description": "Generated test vector #495",
-      "expected": [
-        "filter",
-        "cloth",
-        "dream",
-        "great",
-        "mystery"
-      ]
-    },
-    {
-      "address": "5eKUTN3NwUNEB0qfLb584HalXvT8ZWqrQ2yiHHJsU7e",
-      "description": "Generated test vector #496",
-      "expected": [
-        "grocery",
-        "have",
-        "astute",
-        "hoping",
-        "current"
-      ]
-    },
-    {
-      "address": "osmo1xTfQsZjfqWCGKtd2aatpEAfmRXFdSH7fmffeoDzN6a",
-      "description": "Generated test vector #497",
-      "expected": [
-        "cave",
-        "program",
-        "side",
-        "ride",
-        "hotel"
-      ]
-    },
-    {
-      "address": "IgMzGAhV0zHZiAJm5SxqRmzdmlF28QuRP4",
-      "description": "Generated test vector #498",
-      "expected": [
-        "gusto",
-        "usage",
-        "lucky",
-        "hen",
-        "farm"
-      ]
-    },
-    {
-      "address": "3rfrjzDgetKif1Ap0Gh0rbt1Klkxib7TU0hmHmJl",
-      "description": "Generated test vector #499",
-      "expected": [
-        "swift",
-        "second",
-        "valuable",
-        "yield",
-        "mesmerize"
-      ]
-    },
-    {
-      "address": "3lx8XjTpZzrhsFsXLAaqFAqUTKwBCPM1pPIMkDozWulx7wu0qVyjW",
-      "description": "Generated test vector #500",
-      "expected": [
-        "ingenious",
-        "rich",
-        "sleep",
-        "planet",
-        "place"
-      ]
-    },
-    {
-      "address": "MzsqWwp0Rj2W65ySPuIRRzV2J3Ujm4Uy5",
-      "description": "Generated test vector #501",
-      "expected": [
-        "never",
-        "hotel",
-        "alcohol",
-        "color",
-        "power"
-      ]
-    },
-    {
-      "address": "3gDjCN56UHnq6rIFAPbWyHsDNMUVWef1PFg3FmCbbXDxDkZaf",
-      "description": "Generated test vector #502",
-      "expected": [
-        "sport",
-        "butter",
-        "exhibit",
-        "twenty",
-        "oxygen"
-      ]
-    },
-    {
-      "address": "Y74b3xrmihrWKsVyuriJZk0sUmYLCUKYNsnYq0ePlz4SJfz9bQInnggyk",
-      "description": "Generated test vector #503",
-      "expected": [
-        "cave",
-        "find",
-        "daring",
-        "tomorrow",
-        "frog"
-      ]
-    },
-    {
-      "address": "0xySJqKVfoqqDPZOmQHgcIXqT71EnepHgarOK",
-      "description": "Generated test vector #504",
-      "expected": [
-        "poetic",
-        "upside",
-        "exotic",
-        "grain",
-        "comfort"
-      ]
-    },
-    {
-      "address": "1ct3k4jI205zHc72Lpi7Vp35sqjdted",
-      "description": "Generated test vector #505",
-      "expected": [
-        "deal",
-        "earth",
-        "morning",
-        "ergonomic",
-        "what"
-      ]
-    },
-    {
-      "address": "qzkE6KmHduD12Xh2WgQ5Y9sC1k5IOrh0CNt4",
-      "description": "Generated test vector #506",
-      "expected": [
-        "country",
-        "influential",
-        "robot",
-        "grace",
-        "candy"
-      ]
-    },
-    {
-      "address": "18DFEsALoWe4EMg9hJrpjv2eo5ndLAPyzpvkuUEteiw",
-      "description": "Generated test vector #507",
-      "expected": [
-        "effective",
-        "actual",
-        "gorilla",
-        "business",
-        "trust"
-      ]
-    },
-    {
-      "address": "qzk5CHRrG4ALF8L8bg9RvB64mwF20lNfjz",
-      "description": "Generated test vector #508",
-      "expected": [
-        "glamorous",
-        "notice",
-        "retreat",
-        "salt",
-        "valid"
-      ]
-    },
-    {
-      "address": "osmo1wq2DPf1Or0aYF7AlcRBY2aNYzLP9XgiiDkFgvXkoIlIrHD1GwL",
-      "description": "Generated test vector #509",
-      "expected": [
-        "wolf",
-        "all",
-        "nose",
-        "impulse",
-        "series"
-      ]
-    },
-    {
-      "address": "cosmos1afTICXo3ghpPZ6ttWBjVGiZXB",
-      "description": "Generated test vector #510",
-      "expected": [
-        "opulent",
-        "clump",
-        "lend",
-        "lend",
-        "paddle"
-      ]
-    },
-    {
-      "address": "17IcVGb5be3gr16peuVWF45qDzCTMIkNP5nxUE4N8PoIVPgZM4B54",
-      "description": "Generated test vector #511",
-      "expected": [
-        "forward",
-        "hail",
-        "safe",
-        "godsend",
-        "brilliance"
-      ]
-    },
-    {
-      "address": "5tuuvExJRbVl3az7Jds3GXAxTyAoCq",
-      "description": "Generated test vector #512",
-      "expected": [
-        "bargain",
-        "hail",
-        "spot",
-        "frequent",
-        "that"
-      ]
-    },
-    {
-      "address": "qzkftBfnPeKIinbrDyMN0ssVE4u2arlU",
-      "description": "Generated test vector #513",
-      "expected": [
-        "jeans",
-        "sage",
-        "bread",
-        "dream",
-        "act"
-      ]
-    },
-    {
-      "address": "cosmos1nFVqChgup2LuuC0KbkEYarwd9nOMuLw50t",
-      "description": "Generated test vector #514",
-      "expected": [
-        "spirit",
-        "ethics",
-        "useful",
-        "library",
-        "human"
-      ]
-    },
-    {
-      "address": "Gor4iAl2MfjE6LZbfC5khQK3xn1Zy9YU8hojcG",
-      "description": "Generated test vector #515",
-      "expected": [
-        "likable",
-        "mist",
-        "degree",
-        "client",
-        "honor"
-      ]
-    },
-    {
-      "address": "osmo1lcfKgopxnLfddbROAxlvSPRdT",
-      "description": "Generated test vector #516",
-      "expected": [
-        "edit",
-        "speed",
-        "session",
-        "stairs",
-        "lion"
-      ]
-    },
-    {
-      "address": "osmo1aB9YiaXvXnUfxMCWVrxBrpaTM6vQRgeBE8SvvOOVebJI",
-      "description": "Generated test vector #517",
-      "expected": [
-        "awesome",
-        "chuckle",
-        "decorate",
-        "flame",
-        "ring"
-      ]
-    },
-    {
-      "address": "osmo1HzeSdiehDH5bNDAuimEHKeiYGrFz4frjtbbUCu4JH4jpRmqvOFxLhD7",
-      "description": "Generated test vector #518",
-      "expected": [
-        "plate",
-        "island",
-        "chill",
-        "bounce",
-        "backed"
-      ]
-    },
-    {
-      "address": "cosmos1EIXEve934ifWPbyvRylBXn3dilr6n",
-      "description": "Generated test vector #519",
-      "expected": [
-        "leopard",
-        "dust",
-        "place",
-        "pioneer",
-        "simple"
-      ]
-    },
-    {
-      "address": "bc1q6wy5xDzGFKjrXrwhtMt7J8zx51iP1VU2Sl6TRMKnQqiigBWxajm3C9Q0P",
-      "description": "Generated test vector #520",
-      "expected": [
-        "again",
-        "various",
-        "wood",
-        "seamless",
-        "voyage"
-      ]
-    },
-    {
-      "address": "0x48SC2x1sOCmOGfCQ69ipBTjdJRtSyyTamNP0WYAaeiXjY0",
-      "description": "Generated test vector #521",
-      "expected": [
-        "awake",
-        "dog",
-        "february",
-        "upbeat",
-        "object"
-      ]
-    },
-    {
-      "address": "Fqyp7HmUABJbWk8HzSNRx0Np432Lb94rSd1jMVfIndO3aguy",
-      "description": "Generated test vector #522",
-      "expected": [
-        "glove",
-        "exercise",
-        "swank",
-        "huge",
-        "faucet"
-      ]
-    },
-    {
-      "address": "qzkWGQRd2nGFNTcperqdz3vQZlNgFnttFmMa5Gtrg0Bqf5c3WOzL",
-      "description": "Generated test vector #523",
-      "expected": [
-        "chuckle",
-        "enough",
-        "derive",
-        "faith",
-        "ultra"
-      ]
-    },
-    {
-      "address": "Dgfw5AX8gJDZBJSmmzDctb8HxpNevuRHp79JKVkjyiD",
-      "description": "Generated test vector #524",
-      "expected": [
-        "canyon",
-        "turn",
-        "tremendous",
-        "various",
-        "season"
-      ]
-    },
-    {
-      "address": "qzkIeuY5AE1a2mjFm3CDxKYntNYSkhG6A8aHY6a45hSaCZISkDD",
-      "description": "Generated test vector #525",
-      "expected": [
-        "predict",
-        "active",
-        "any",
-        "correct",
-        "canal"
-      ]
-    },
-    {
-      "address": "qzkhVstQDFyaLa4jci1isrnQdTDYP9fM5SAhJ",
-      "description": "Generated test vector #526",
-      "expected": [
-        "redeemed",
-        "tilt",
-        "intuitive",
-        "couch",
-        "family"
-      ]
-    },
-    {
-      "address": "qzkxSAVyCsLSx0mWaMwkZriPQwWM7lZJVpMa",
-      "description": "Generated test vector #527",
-      "expected": [
-        "icon",
-        "fulfill",
-        "nifty",
-        "elbow",
-        "various"
-      ]
-    },
-    {
-      "address": "0xQDpdhENh4uUfeR4zbcyISP04L14mtFSw3LgJDfpp3FzN0Qoj2f9",
-      "description": "Generated test vector #528",
-      "expected": [
-        "rabbit",
-        "bullish",
-        "shaft",
-        "what",
-        "befit"
-      ]
-    },
-    {
-      "address": "qzkYzwWiyu1KkSPrcc2PiHPfPxbfbVrZEh7mdN",
-      "description": "Generated test vector #529",
-      "expected": [
-        "seek",
-        "more",
-        "multiply",
-        "prowess",
-        "desert"
-      ]
-    },
-    {
-      "address": "bc1qtAOnLV3YfdSKGKoIGTYtZ7kN6u7dH6UMdTdqnBApz",
-      "description": "Generated test vector #530",
-      "expected": [
-        "journey",
-        "coconut",
-        "point",
-        "more",
-        "bamboo"
-      ]
-    },
-    {
-      "address": "34bWf9PAe01JW38V024n91f8Q6PTaLEmBF8fKhtPLDz1OUgYAQgEy3OH7zoH4PbT",
-      "description": "Generated test vector #531",
-      "expected": [
-        "couch",
-        "urban",
-        "flying",
-        "garlic",
-        "ginger"
-      ]
-    },
-    {
-      "address": "5CyKlABZFJQBy69ul4L3HLCKotHivDCA8ZxbZ4wU",
-      "description": "Generated test vector #532",
-      "expected": [
-        "salamander",
-        "library",
-        "shock",
-        "siren",
-        "foam"
-      ]
-    },
-    {
-      "address": "0xbeS5hB3WuIleZK6vyXHBO0tAdOVaLqKNGBZEN9MNVKbg2vaN",
-      "description": "Generated test vector #533",
-      "expected": [
-        "hot",
-        "reopen",
-        "desk",
-        "below",
-        "stuff"
-      ]
-    },
-    {
-      "address": "5EkUbPLjlolLYNakcWEm6YW4OAqXBo6T",
-      "description": "Generated test vector #534",
-      "expected": [
-        "radio",
-        "define",
-        "help",
-        "poetic",
-        "baby"
-      ]
-    },
-    {
-      "address": "cosmos1Ru2QYVs67wzWEdx3Wws6nuex",
-      "description": "Generated test vector #535",
-      "expected": [
-        "panic",
-        "leaf",
-        "phrase",
-        "explain",
-        "type"
-      ]
-    },
-    {
-      "address": "5Pz5FP2FWI1P5O6N0Zn8ZGobPCwD53sj2zXIOOs2T9Q1bbSsXwSKGykZdmk9LmcC",
-      "description": "Generated test vector #536",
-      "expected": [
-        "dolphin",
-        "today",
-        "begin",
-        "feisty",
-        "lush"
-      ]
-    },
-    {
-      "address": "bc1q40KqWvMQo5diIvvPQNsvO7fnoe4KVQQZUMZueS4govb9kw2YjAP4XvQGE",
-      "description": "Generated test vector #537",
-      "expected": [
-        "deal",
-        "top",
-        "cabbage",
-        "rigorous",
-        "erase"
-      ]
-    },
-    {
-      "address": "IPvveNAcL4fofD3sZtQQR5zDHgCppf00PZxAS1kA2k",
-      "description": "Generated test vector #538",
-      "expected": [
-        "faculty",
-        "eight",
-        "control",
-        "embrace",
-        "main"
-      ]
-    },
-    {
-      "address": "5FGFWBjK5AoLAb05L6BEduSSYH4hPSB",
-      "description": "Generated test vector #539",
-      "expected": [
-        "brick",
-        "crisp",
-        "wombat",
-        "build",
-        "heaven"
-      ]
-    },
-    {
-      "address": "17nWZGI7tv6OOdwYyw1ikSgpDVBCLdSsbrq3GROp2",
-      "description": "Generated test vector #540",
-      "expected": [
-        "ingenious",
-        "lunar",
-        "skate",
-        "savings",
-        "need"
-      ]
-    },
-    {
-      "address": "osmo14fcOj8DhNtzQhPCh47Y4nkgAQfdFoMjKpJetnCW",
-      "description": "Generated test vector #541",
-      "expected": [
-        "isolate",
-        "pottery",
-        "extra",
-        "already",
-        "common"
-      ]
-    },
-    {
-      "address": "1wJQEBs0T0f1dqdYliOUGIIcn6N2kty",
-      "description": "Generated test vector #542",
-      "expected": [
-        "shock",
-        "kidney",
-        "section",
         "produce",
-        "elite"
-      ]
-    },
-    {
-      "address": "5oWqLSmzQQseSjWHfepIikdUgpxgtjgHH",
-      "description": "Generated test vector #543",
-      "expected": [
-        "cousin",
-        "extra",
-        "fabric",
-        "tattoo",
-        "aspect"
-      ]
-    },
-    {
-      "address": "osmo1kVTQeUxhWzzaHPQOR9TLCFROAlcvfRgdDahoI2bO",
-      "description": "Generated test vector #544",
-      "expected": [
-        "dazzling",
-        "web",
-        "brown",
-        "flying",
-        "preeminent"
-      ]
-    },
-    {
-      "address": "gnaxV2KeqNw5ADMvyhlAeBTYQPFU0ovgUVxWH6xECm0GUZcTnO",
-      "description": "Generated test vector #545",
-      "expected": [
-        "expire",
-        "frequent",
-        "verify",
-        "slab",
-        "savvy"
-      ]
-    },
-    {
-      "address": "cosmos17sW2kATa6gXzfsMglFgyGA3zD0yx8yFDbxI7arnQ5oTQev8",
-      "description": "Generated test vector #546",
-      "expected": [
-        "cabbage",
-        "climb",
-        "evidence",
-        "age",
-        "hardy"
-      ]
-    },
-    {
-      "address": "3Pk5xLrcqx6ifHkFrhlfhRV6O0DPGTZGpJ3KB",
-      "description": "Generated test vector #547",
-      "expected": [
-        "depart",
-        "mountain",
-        "soup",
-        "never",
-        "nuclear"
-      ]
-    },
-    {
-      "address": "0xj1ghr0X9wTIHg68AENQ7Rzp9mfK8wvYUUgKLn4Ff0n0SO2dG",
-      "description": "Generated test vector #548",
-      "expected": [
-        "device",
-        "grace",
-        "marine",
-        "boy",
-        "peerless"
-      ]
-    },
-    {
-      "address": "3hmZEAElQkyXQAhZeMGqc0tLdDkwsFunR",
-      "description": "Generated test vector #549",
-      "expected": [
-        "stadium",
-        "once",
-        "name",
-        "begin",
-        "rigorous"
-      ]
-    },
-    {
-      "address": "bc1qj09nNjt7vBqZRlI2N04ZZ134gRllYhHoL",
-      "description": "Generated test vector #550",
-      "expected": [
-        "amazing",
-        "yard",
-        "rapture",
-        "practice",
-        "bid"
-      ]
-    },
-    {
-      "address": "osmo1gmVpotndp3XLGTWMOAPwWHirTIULkgDWlOVfyd2nM",
-      "description": "Generated test vector #551",
-      "expected": [
-        "cabbage",
-        "preeminent",
-        "invest",
-        "love",
-        "tact"
-      ]
-    },
-    {
-      "address": "bc1qCDiDosa5sOOT6fM20oYz4lot3fHOtqs82qPPjrYUaLBv3fPFO8zqL",
-      "description": "Generated test vector #552",
-      "expected": [
-        "venue",
-        "endorse",
-        "dwarf",
-        "magic",
-        "upbeat"
-      ]
-    },
-    {
-      "address": "cosmos1tvMMelctNsufNd4l1PYeNttqUKkNk",
-      "description": "Generated test vector #553",
-      "expected": [
-        "coffee",
-        "sublime",
-        "suggest",
-        "unveil",
-        "ask"
-      ]
-    },
-    {
-      "address": "qzkSAP9LWJoHfpZMHULbMoXhO1sxPFlzmsGL7pDg7GBLTFWwrrTk66",
-      "description": "Generated test vector #554",
-      "expected": [
-        "oak",
-        "facilitate",
-        "dress",
-        "royal",
-        "token"
-      ]
-    },
-    {
-      "address": "vBmYb1kVI4GMxq9DNaJYL7rmL0DuqhImcKKqI6nrrTNPGABHJCz",
-      "description": "Generated test vector #555",
-      "expected": [
-        "foster",
-        "ribbon",
-        "input",
-        "perfect",
-        "ramp"
-      ]
-    },
-    {
-      "address": "1R1b11KfqBfbVXq6S6gyZzTauHF6QxPq2QmR8w38Ju29rVbuz1J6EtiS33X",
-      "description": "Generated test vector #556",
-      "expected": [
-        "dazzling",
-        "claim",
-        "cipher",
-        "arrive",
-        "solid"
-      ]
-    },
-    {
-      "address": "5DRK3Xh70u8QouREUU2s9ezUGrpU11PmFn",
-      "description": "Generated test vector #557",
-      "expected": [
-        "forest",
-        "ingenious",
-        "solid",
-        "tool",
-        "trust"
-      ]
-    },
-    {
-      "address": "1V0iIxu7LmVNFw44EvxD3yzdmApQnKy",
-      "description": "Generated test vector #558",
-      "expected": [
-        "fidelity",
-        "pudding",
-        "affinity",
-        "toast",
-        "front"
-      ]
-    },
-    {
-      "address": "5oHPjnBAD03BnhBrwCAP3y6BtcM44LYqEVxqrorFuK0BC",
-      "description": "Generated test vector #559",
-      "expected": [
-        "usual",
-        "ethics",
-        "slab",
-        "exultant",
-        "levity"
-      ]
-    },
-    {
-      "address": "cosmos17WDCIrqj7DCeKvseUVOmMdcS",
-      "description": "Generated test vector #560",
-      "expected": [
-        "punctual",
-        "coil",
-        "model",
-        "annual",
-        "banana"
-      ]
-    },
-    {
-      "address": "cosmos1XxwFpsqp8XOAp741iz8N4Pa7q",
-      "description": "Generated test vector #561",
-      "expected": [
-        "daring",
-        "engage",
-        "scan",
-        "poem",
-        "cricket"
-      ]
-    },
-    {
-      "address": "0xeTYKUwAeQLJTZ9fg2FUB5yeTDAfNOFPrC",
-      "description": "Generated test vector #562",
-      "expected": [
-        "ghost",
-        "beam",
-        "once",
-        "december",
-        "nice"
-      ]
-    },
-    {
-      "address": "5P1ZHjMTSwvLxGMrkooTJlArbrDpHkjpvnfybEBpIZpTFkC1Zauqg5U",
-      "description": "Generated test vector #563",
-      "expected": [
-        "leopard",
-        "machine",
-        "picnic",
-        "people",
-        "school"
-      ]
-    },
-    {
-      "address": "3WDnwf4QUzt1Esm84ePawxq6ztYv66WwkhIu2YdJs2Xe",
-      "description": "Generated test vector #564",
-      "expected": [
-        "zest",
-        "hockey",
-        "tag",
-        "smitten",
-        "drop"
-      ]
-    },
-    {
-      "address": "3uY08gCUlH6gnH7f3VT97eqxqR8k4gLwC0800TgdtDlffSfpuNw07t",
-      "description": "Generated test vector #565",
-      "expected": [
-        "calm",
-        "parent",
-        "ticket",
-        "keep",
-        "violin"
-      ]
-    },
-    {
-      "address": "0xdtaBfS3M3zMsVtz0AUs9sWUlKi61LvdtfMTgzgRx",
-      "description": "Generated test vector #566",
-      "expected": [
-        "minute",
-        "space",
-        "river",
-        "two",
-        "company"
-      ]
-    },
-    {
-      "address": "5b330TNjpXhHzFhQNE5yOxMW7bmqJ5favoP",
-      "description": "Generated test vector #567",
-      "expected": [
-        "right",
-        "bear",
-        "direct",
-        "panda",
-        "small"
-      ]
-    },
-    {
-      "address": "osmo1iiMdmjcOC0IMTplChLfu3Yu92Xb546yXcIk5laW02q7y87cJpfFTFB7q",
-      "description": "Generated test vector #568",
-      "expected": [
-        "tranquil",
-        "upside",
-        "usage",
-        "ostrich",
-        "melt"
-      ]
-    },
-    {
-      "address": "0x3u0AiFEFFTxA88MomOdO2iK29X1IarZrU3",
-      "description": "Generated test vector #569",
-      "expected": [
-        "alert",
-        "oval",
-        "march",
-        "top",
-        "income"
-      ]
-    },
-    {
-      "address": "1nbuVT1GXVTI6JtKUqYT7oBIK27znd",
-      "description": "Generated test vector #570",
-      "expected": [
-        "adorable",
-        "culture",
-        "that",
-        "film",
-        "sleep"
-      ]
-    },
-    {
-      "address": "osmo1hTEYpFGYGVZuQj3wPPP2j4S3VgnpmBFvHs6A4NF",
-      "description": "Generated test vector #571",
-      "expected": [
-        "clinic",
-        "fiction",
-        "tops",
-        "remind",
-        "panel"
-      ]
-    },
-    {
-      "address": "5uIDqruJuewm6tvWuM5REHCr7dN8x35AuhUhMEpnMwtVWB2",
-      "description": "Generated test vector #572",
-      "expected": [
-        "much",
-        "cool",
-        "abundance",
-        "rain",
-        "faith"
-      ]
-    },
-    {
-      "address": "5GA5aYJmTYdgWZfTJOj5iGVXnVLDzdMVBR7X28rXmsaZunUx2y9E5uq2vK",
-      "description": "Generated test vector #573",
-      "expected": [
-        "outreach",
-        "add",
-        "sword",
-        "comfort",
-        "cross"
-      ]
-    },
-    {
-      "address": "5MB15ZyREcum50sJgQSYvBMQXwc8268S",
-      "description": "Generated test vector #574",
-      "expected": [
-        "win",
-        "dauntless",
-        "popular",
-        "bronze",
-        "exact"
-      ]
-    },
-    {
-      "address": "bc1q1PC2Ifjlq6wDFryBLZZZfWIJgFCxeJQsXLkmg4MlV",
-      "description": "Generated test vector #575",
-      "expected": [
-        "helmet",
-        "round",
-        "wheel",
-        "sparkle",
-        "pleasant"
-      ]
-    },
-    {
-      "address": "bc1qWuJqBvWKcbuSqXnZnVHOg1XkiaKV1dz6o1vwChdchupCor7oe3qHivw7upn",
-      "description": "Generated test vector #576",
-      "expected": [
-        "emotion",
-        "fan",
-        "uncover",
-        "egg",
-        "walk"
-      ]
-    },
-    {
-      "address": "cosmos1tyuOCMtoiwxIZPK8vUsE5gzcW4VqNWzoTO7sabgyK8NfTEKSYQ8hvt",
-      "description": "Generated test vector #577",
-      "expected": [
-        "device",
-        "bamboo",
-        "likable",
-        "right",
-        "intricate"
-      ]
-    },
-    {
-      "address": "osmo1Gn6xVcClZgevQOcgU6CXqcHRlGt",
-      "description": "Generated test vector #578",
-      "expected": [
-        "group",
-        "ovation",
-        "jungle",
-        "yellow",
-        "tag"
-      ]
-    },
-    {
-      "address": "14jUwYoIXKBPvmA9wPwGzECiHqfnXYULelL4tEtMA05tSTzV26q7mV8",
-      "description": "Generated test vector #579",
-      "expected": [
-        "stay",
-        "fence",
-        "unbeatable",
-        "benefit",
-        "dolphin"
-      ]
-    },
-    {
-      "address": "0x4PowM0IjZF8v6PoTY6RXiFVy6gYP7Xk",
-      "description": "Generated test vector #580",
-      "expected": [
-        "jump",
-        "burst",
-        "strong",
-        "mesmerize",
-        "point"
-      ]
-    },
-    {
-      "address": "cosmos1tjx5KWHXjuMs8VBqNxxnxYr5ggVH04vn5",
-      "description": "Generated test vector #581",
-      "expected": [
-        "embark",
-        "name",
-        "voice",
-        "consider",
-        "will"
-      ]
-    },
-    {
-      "address": "bc1q7QimZNgKB6AsgWrEexibePppqdglkmymF2ys4cJ9PDgHWxTxDOQez7EcH0",
-      "description": "Generated test vector #582",
-      "expected": [
-        "connect",
-        "march",
-        "isolate",
-        "satisfy",
-        "amiable"
-      ]
-    },
-    {
-      "address": "5OgyJc2PysuyMCgLyu4ULbWpXcJREasuP",
-      "description": "Generated test vector #583",
-      "expected": [
-        "divert",
-        "blockbuster",
-        "catalog",
-        "solution",
-        "tolerant"
-      ]
-    },
-    {
-      "address": "1Qhe1IgyHJCarhupLNyi27yakATUIFwra15oVwoFsQMfzB2uft4xnQvbkf",
-      "description": "Generated test vector #584",
-      "expected": [
+        "splendid",
         "silk",
-        "quantum",
-        "switch",
-        "tourist",
-        "simple"
-      ]
-    },
-    {
-      "address": "0xjHlJw6KDJ5vVLg5fEbczCdJep5xu7pYVN",
-      "description": "Generated test vector #585",
-      "expected": [
-        "arrange",
-        "very",
-        "else",
-        "talent",
-        "give"
-      ]
-    },
-    {
-      "address": "osmo1oxqUCZC1Bdynu705XCN00NDookJAZSuUE89vWs",
-      "description": "Generated test vector #586",
-      "expected": [
-        "affection",
-        "solve",
-        "tornado",
-        "panel",
-        "advocate"
-      ]
-    },
-    {
-      "address": "cosmos11KR8SnhfvbvrDCWK6YSsDZgd7Jy2wPvvjJCkQnFq9bmaF7x1TaASTl1O1",
-      "description": "Generated test vector #587",
-      "expected": [
-        "health",
-        "green",
-        "autumn",
-        "sample",
-        "wrist"
-      ]
-    },
-    {
-      "address": "1G5WDM123BxcOJ3zxEK2Y5eWdBowiLkOcH34rkl6oWn",
-      "description": "Generated test vector #588",
-      "expected": [
-        "prosper",
-        "cabin",
-        "length",
-        "uncover",
-        "summer"
-      ]
-    },
-    {
-      "address": "bc1qrbyRb06J8RQaLOlB2uisivDZcx6p2IrD6phJUXWpw7",
-      "description": "Generated test vector #589",
-      "expected": [
-        "dad",
-        "voyage",
-        "square",
-        "flash",
-        "confirm"
-      ]
-    },
-    {
-      "address": "3Xu8z98wXD16INByQcS6kpeD3f84I756WPHDGE5GmXeXXJXkYDPysAoVHFDbecG",
-      "description": "Generated test vector #590",
-      "expected": [
-        "polished",
-        "lavender",
-        "balcony",
-        "panel",
-        "renaissance"
-      ]
-    },
-    {
-      "address": "cosmos1QjbQTOaSEs6erEi1e1qz2tTWwzQBrZoSdHVsH6la7FE3",
-      "description": "Generated test vector #591",
-      "expected": [
-        "tomorrow",
-        "earn",
-        "young",
-        "cargo",
-        "liking"
-      ]
-    },
-    {
-      "address": "yRadfqBKoyeTGFgNawSJE88PbieihIIShojJ0ZJ0UKF",
-      "description": "Generated test vector #592",
-      "expected": [
-        "pizza",
-        "hold",
-        "polished",
-        "mother",
-        "chef"
-      ]
-    },
-    {
-      "address": "1H644Ye0XOfL84CZCRgXtlIDozxve5oesJ8XDBVORCkUsNm21MC",
-      "description": "Generated test vector #593",
-      "expected": [
-        "immaculate",
-        "merge",
-        "example",
-        "mention",
-        "indicate"
-      ]
-    },
-    {
-      "address": "qzkL1wg4U0nGPcj4cXqHbssKzdbdrLzvozrkxWRi",
-      "description": "Generated test vector #594",
-      "expected": [
-        "custom",
-        "yield",
-        "credit",
-        "luxury",
-        "blameless"
-      ]
-    },
-    {
-      "address": "osmo1K5nWoKf75NdguCgSUllteE1A8aaeq4XnuGTBsjHpX",
-      "description": "Generated test vector #595",
-      "expected": [
-        "eight",
-        "preeminent",
-        "ramp",
-        "silly",
-        "memory"
-      ]
-    },
-    {
-      "address": "osmo1Q4DD58pKWkVksToucmLac8dsCe0tjFpTuq6SrNhMLSUTBw16nm7",
-      "description": "Generated test vector #596",
-      "expected": [
-        "pair",
-        "hospital",
-        "day",
-        "pretty",
-        "home"
-      ]
-    },
-    {
-      "address": "5r0TP1XQkDRumZZgnbDrp3Qd9AglsDp",
-      "description": "Generated test vector #597",
-      "expected": [
-        "upside",
-        "egg",
-        "what",
-        "pitch",
-        "member"
-      ]
-    },
-    {
-      "address": "lYjovuecpifbRwwHEX7q9dj3YP6yeKjY1ioXcEGK0YT24vUTt758M",
-      "description": "Generated test vector #598",
-      "expected": [
-        "violin",
-        "relax",
-        "motor",
-        "nominee",
-        "smile"
-      ]
-    },
-    {
-      "address": "qzkuEUw63yXkFO8zbWhz0ePHw6AtaWC6trdLO",
-      "description": "Generated test vector #599",
-      "expected": [
-        "glove",
-        "acclaim",
-        "emotion",
-        "divert",
-        "tenant"
-      ]
-    },
-    {
-      "address": "PAB2sQQA4FUKgerUT0TLEFFgKcX3OxpGzFRTfYvAK9MOx9VHjDGa",
-      "description": "Generated test vector #600",
-      "expected": [
-        "supreme",
-        "knock",
-        "rough",
-        "museum",
-        "noble"
-      ]
-    },
-    {
-      "address": "3jaNIP6sjlnAbFTSbHdyB2VK9xNvrIz3qDI6xFzx1uEgAvcPXYms5fdMBKjSi",
-      "description": "Generated test vector #601",
-      "expected": [
-        "chaos",
-        "stereo",
-        "desk",
-        "butter",
-        "umbrella"
-      ]
-    },
-    {
-      "address": "AVnVRDpPgEIgW0grDj0iPixYubdvKb9SPKIm0yCGDtgnmXrGVdbe",
-      "description": "Generated test vector #602",
-      "expected": [
-        "star",
-        "detail",
-        "travel",
-        "lend",
-        "ten"
-      ]
-    },
-    {
-      "address": "bc1qjt69E8rBJ7z9zyFEmgLxjjWNdkpi3rxUB07lewIcq50k12",
-      "description": "Generated test vector #603",
-      "expected": [
-        "praise",
-        "pave",
-        "velvet",
-        "easy",
-        "giggle"
-      ]
-    },
-    {
-      "address": "0xeycHhlJEIVEMKxmfiyuIY1sjiXqIpHySpCCsc6Z24bjQNY5WL",
-      "description": "Generated test vector #604",
-      "expected": [
-        "seamless",
-        "genre",
-        "know",
-        "teach",
-        "wish"
-      ]
-    },
-    {
-      "address": "bc1qafq5W2JUZYXMT0xOL3TzIWr8nefUFg11Nt6vfRjNBKatcwaUXY3C",
-      "description": "Generated test vector #605",
-      "expected": [
-        "impact",
-        "dew",
-        "where",
-        "shrimp",
-        "exuberance"
-      ]
-    },
-    {
-      "address": "cosmos1CnbgYv4qD6ju8LXCqn16qMJ5Ga6pgoU9rlN7eZbkVBoeOcE6oQcbHzu",
-      "description": "Generated test vector #606",
-      "expected": [
-        "stove",
-        "subject",
-        "barn",
-        "rejoice",
-        "prosper"
-      ]
-    },
-    {
-      "address": "5koc5brsGCsIWNYKFGC3pYbd3XaeE71Ot4KY",
-      "description": "Generated test vector #607",
-      "expected": [
-        "ensure",
-        "toddler",
-        "leopard",
-        "cooperate",
-        "raw"
-      ]
-    },
-    {
-      "address": "0xGg2BJVZ9rb5qs6YuKBooPsJzRv6o9DQYTw42UtRKlM8nxgTDZo9nJsA4",
-      "description": "Generated test vector #608",
-      "expected": [
-        "stove",
-        "flavor",
-        "spatial",
-        "bundle",
-        "island"
-      ]
-    },
-    {
-      "address": "cosmos1ES5mUIvG18pM1OyCfR97qmhV4y6AwIg2ZCh2hibRKL5xqsmKRBgs8Ow",
-      "description": "Generated test vector #609",
-      "expected": [
-        "index",
-        "loyal",
-        "time",
-        "certain",
-        "clap"
-      ]
-    },
-    {
-      "address": "0xLoPD0gHy7KjtL0db5ydce7YPUfueeKlppVMFifocTF",
-      "description": "Generated test vector #610",
-      "expected": [
-        "fuel",
-        "reform",
-        "picture",
-        "empathize",
-        "buzz"
-      ]
-    },
-    {
-      "address": "bc1q0PxJdQ64Y0Dm5eqqhP6CMMz3wtzLhe9H2bnfTyrDdN8nblqhMLAl4Le0Aap",
-      "description": "Generated test vector #611",
-      "expected": [
-        "dignity",
-        "pulse",
-        "cure",
-        "world",
-        "material"
-      ]
-    },
-    {
-      "address": "bc1qSTO8i3j2XX4k3oKLMt16t4zpsGVp5N",
-      "description": "Generated test vector #612",
-      "expected": [
-        "message",
-        "educate",
-        "elephant",
-        "holiday",
-        "system"
-      ]
-    },
-    {
-      "address": "F22eWncpLGtEfuRKORV4RkDDLkwgjSqyokz27ybjusHaMvMJEVS8XmZ80",
-      "description": "Generated test vector #613",
-      "expected": [
-        "raise",
-        "god",
-        "oblige",
-        "luster",
-        "prolific"
-      ]
-    },
-    {
-      "address": "osmo1e7YpBQeDny5aSA7yO1gj6s0mbacypUFj7M9IFn41XcDSGfN",
-      "description": "Generated test vector #614",
-      "expected": [
-        "flourish",
-        "universe",
-        "godsend",
-        "moral",
-        "bird"
-      ]
-    },
-    {
-      "address": "bc1q8VsvlDaM0IiDZeQjMA3NujTuuQb72chsHphAkQaz9iocUGa4PQ2Nm",
-      "description": "Generated test vector #615",
-      "expected": [
-        "stay",
-        "seminar",
-        "artist",
-        "round",
-        "size"
-      ]
-    },
-    {
-      "address": "qzkYJ8Vi7bL2RnA3AxITsp1prp6yBqCbHrTIgTfzi6ZkaifwtbL",
-      "description": "Generated test vector #616",
-      "expected": [
-        "valor",
-        "window",
-        "soap",
-        "savings",
-        "wedding"
-      ]
-    },
-    {
-      "address": "5gSmukujpkO85uZlCBsvqdRSEz6UPKcghujuFAlBHHyn8rK8b4w33FRK",
-      "description": "Generated test vector #617",
-      "expected": [
-        "caution",
-        "strong",
-        "monitor",
-        "purity",
-        "focus"
-      ]
-    },
-    {
-      "address": "1AX0t3l9n7uQsTKluXIBBL8fQW9XnRVC8BpVQfyI808J4cU2O7lWmRKxaFqAUiFJ",
-      "description": "Generated test vector #618",
-      "expected": [
-        "style",
-        "alone",
-        "mushroom",
-        "myth",
-        "crystal"
-      ]
-    },
-    {
-      "address": "a9EyghpZLNJ1KCN5R541nGEHGvZFT7IMyOHVW8CRd4JN",
-      "description": "Generated test vector #619",
-      "expected": [
-        "faultless",
-        "universe",
-        "display",
-        "poignant",
-        "recipe"
-      ]
-    },
-    {
-      "address": "qzkErKLWTZWtQNpXr0cy4kAxVvOsCvJQbXqvOF5F7N1TC",
-      "description": "Generated test vector #620",
-      "expected": [
-        "match",
-        "exquisite",
-        "boring",
-        "dry",
-        "write"
-      ]
-    },
-    {
-      "address": "5FtFnPuPXeDtZ9PE7n9OgQC7f5NlONaFnKjmSta4zKv7uVTnV75Qy",
-      "description": "Generated test vector #621",
-      "expected": [
-        "cheese",
-        "grain",
-        "tops",
-        "mansion",
-        "food"
-      ]
-    },
-    {
-      "address": "bc1qCtPuhMjKdihqEsXucpwwR9c8czDezt6XIXXg",
-      "description": "Generated test vector #622",
-      "expected": [
-        "improve",
-        "motor",
-        "scan",
-        "clump",
-        "cluster"
-      ]
-    },
-    {
-      "address": "3IpPfNDTW0uBz4kj8OONwszRpapwYvuhzRAE",
-      "description": "Generated test vector #623",
-      "expected": [
-        "chivalrous",
-        "tender",
-        "guide",
-        "expire",
-        "cash"
-      ]
-    },
-    {
-      "address": "qzkLP5nOE1lSdQzblTpJS8Z6A5b6ldB6PyCLA6C4evgcm0pLCL34xTImoQoT1eKJ",
-      "description": "Generated test vector #624",
-      "expected": [
-        "cradle",
-        "bid",
-        "lenient",
-        "attract",
-        "light"
-      ]
-    },
-    {
-      "address": "5g0nDj5cdI2FOBrCdrIEH3W35dljOZUbe9AJdsz",
-      "description": "Generated test vector #625",
-      "expected": [
-        "renaissance",
-        "melt",
-        "lounge",
-        "creek",
-        "bolster"
-      ]
-    },
-    {
-      "address": "5FuTqz0zQbAZqjM49kCCCpE4qBYRqtDWdAiMFC5HjGXiXjySRUpBa",
-      "description": "Generated test vector #626",
-      "expected": [
-        "cover",
-        "elated",
-        "hottest",
-        "interest",
-        "hotel"
-      ]
-    },
-    {
-      "address": "bc1qeFAuTyFXe0Nx98JwdCG32V9iQoxQfybJfMQIGaRDQWQE3wcCg6Drrn8JT",
-      "description": "Generated test vector #627",
-      "expected": [
-        "hoping",
-        "lucrative",
-        "news",
-        "dao",
-        "dentist"
-      ]
-    },
-    {
-      "address": "5ROsfd8f5JaPdgIwTacvrDQ5oQkf9k3D4XDOPO1uoLt19UpVvxQMUPkrzh",
-      "description": "Generated test vector #628",
-      "expected": [
-        "square",
-        "outreach",
-        "salamander",
-        "remain",
-        "awake"
-      ]
-    },
-    {
-      "address": "bc1qs6W0f3lCWLoBAUTVQBHU3VaGvVYCLcwsSGeqLFnYuyrcwpuJJBlxpj",
-      "description": "Generated test vector #629",
-      "expected": [
-        "dutch",
-        "answer",
-        "turtle",
-        "teach",
-        "review"
-      ]
-    },
-    {
-      "address": "qzkghQdRxQeHzAFI9tnkpZzFmYCROQ0aV2j1",
-      "description": "Generated test vector #630",
-      "expected": [
-        "likable",
-        "tomato",
-        "salad",
-        "affluence",
-        "pet"
-      ]
-    },
-    {
-      "address": "cosmos1v8E5a0sZZG2EX1SidVr8pTrsakpCgS4Q",
-      "description": "Generated test vector #631",
-      "expected": [
-        "blessing",
-        "announce",
-        "together",
-        "evolve",
-        "doctor"
-      ]
-    },
-    {
-      "address": "3qelucqXM3A10MFOC9G6urF2V7oa45i698z",
-      "description": "Generated test vector #632",
-      "expected": [
-        "space",
-        "chunk",
-        "joyous",
-        "save",
-        "heart"
-      ]
-    },
-    {
-      "address": "0x7ARu99Kp3Fbjr8rsLAWvh28zXii51d6COupbtoxiiNspnBPY4",
-      "description": "Generated test vector #633",
-      "expected": [
-        "flash",
-        "frequent",
-        "soft",
-        "unified",
-        "work"
-      ]
-    },
-    {
-      "address": "qzkHNks2vldYieHaHl4HX4zt2v1uyoARsG",
-      "description": "Generated test vector #634",
-      "expected": [
-        "news",
-        "snow",
-        "record",
-        "gem",
-        "phone"
-      ]
-    },
-    {
-      "address": "0xMIGuekPRxK4t7qKSGtH3909BcjpP0kMI4fT1mj",
-      "description": "Generated test vector #635",
-      "expected": [
-        "praise",
-        "verb",
-        "wonder",
-        "jacket",
-        "museum"
-      ]
-    },
-    {
-      "address": "0x16G8hB2DyAHPuDGT8SjF4Boq87alHZqNYU8Nwp3k7",
-      "description": "Generated test vector #636",
-      "expected": [
-        "reveal",
-        "brush",
-        "laud",
-        "pair",
-        "facilitate"
-      ]
-    },
-    {
-      "address": "3EScpnGRDdhCUPhIYY5bRWcTjvszLWQ8X38OsgDI0eWAWr1CG09vLs7F5q",
-      "description": "Generated test vector #637",
-      "expected": [
-        "voice",
-        "vapor",
-        "street",
-        "wet",
-        "camel"
-      ]
-    },
-    {
-      "address": "5UmSMeQrLvCQbOAkPqt0QrjrEbIudhSn7JbhSFfVinwId3H9cP6wnCZmzbNBk",
-      "description": "Generated test vector #638",
-      "expected": [
-        "rapport",
-        "speed",
-        "iron",
-        "wild",
-        "rejoice"
-      ]
-    },
-    {
-      "address": "qzk95wAMC4Ps7vvJ8bv3oNiSfhF27renvj",
-      "description": "Generated test vector #639",
-      "expected": [
-        "record",
-        "skate",
-        "alcohol",
-        "train",
-        "open"
-      ]
-    },
-    {
-      "address": "osmo1TPwYdCPG8kVyt2LSfZxssjXcYiNV2CbTH",
-      "description": "Generated test vector #640",
-      "expected": [
-        "bridge",
-        "raven",
-        "tingle",
-        "festival",
-        "next"
-      ]
-    },
-    {
-      "address": "cosmos1lTQpSfk92rTkmVoNXbpkSZ3wZk",
-      "description": "Generated test vector #641",
-      "expected": [
-        "virtual",
-        "prefer",
-        "hire",
-        "pencil",
-        "soap"
-      ]
-    },
-    {
-      "address": "qzkKdb5D4fXO4uzf3f7hXTToXSDmLQAkCHfEshVjVM2RF9cr1I",
-      "description": "Generated test vector #642",
-      "expected": [
-        "away",
-        "athlete",
-        "glamorous",
-        "fix",
-        "hat"
-      ]
-    },
-    {
-      "address": "36dHGexzYjhJP1cjPlyIYmBjV2ME98SReEaOQ3fhFVst1gSWb3p7qwbEpGVvZEv",
-      "description": "Generated test vector #643",
-      "expected": [
-        "pepper",
-        "antenna",
-        "burden",
-        "song",
-        "alter"
-      ]
-    },
-    {
-      "address": "3ROjexUhbmENTf8P8dVQB0bl1L1mA1bvLyLZyQpS9pQdEUtYWJ1e",
-      "description": "Generated test vector #644",
-      "expected": [
-        "setup",
-        "hydra",
-        "aura",
-        "hail",
-        "image"
-      ]
-    },
-    {
-      "address": "0xmls0Xz3Ws2HGl2kDLaJlG34Zix6Uw9gMhJAbnt1WoEImSm20l7GcRz",
-      "description": "Generated test vector #645",
-      "expected": [
-        "choice",
-        "exotic",
-        "combine",
-        "witty",
-        "drill"
-      ]
-    },
-    {
-      "address": "qzkGz3qADSgoViygu3JDcqFagUqXwlgtnxezxgxbmxfLyUWvRq84k",
-      "description": "Generated test vector #646",
-      "expected": [
-        "reflect",
-        "spoil",
-        "flamingo",
-        "supple",
-        "crisp"
-      ]
-    },
-    {
-      "address": "58xU5689EfqbrXqQruJPWboafLz8jW78xK4QQOTVUXyGHO26uQB8KqWLfQ4chl",
-      "description": "Generated test vector #647",
-      "expected": [
-        "serene",
-        "skin",
-        "spatial",
-        "diligent",
-        "excite"
-      ]
-    },
-    {
-      "address": "cosmos1oYMIlUDCaAY5uOuSsl7pMyJs",
-      "description": "Generated test vector #648",
-      "expected": [
-        "step",
-        "leader",
-        "make",
-        "bottom",
-        "clutch"
-      ]
-    },
-    {
-      "address": "10RvADkaaz533Se9msJWRtlthznokrTLSQQcfaI6hSrOB7To12W6srR0kRN3",
-      "description": "Generated test vector #649",
-      "expected": [
-        "opulent",
-        "panda",
-        "leopard",
-        "reason",
-        "animal"
-      ]
-    },
-    {
-      "address": "bc1qSVW23mnkHDwzE9hm4zuqCSffGiT9Z177PGKeSaTh9hsypS",
-      "description": "Generated test vector #650",
-      "expected": [
-        "purity",
-        "orient",
-        "hand",
-        "lean",
-        "initial"
-      ]
-    },
-    {
-      "address": "191oVCXkV2E7YP41V8lESDsP8EaDIhjpuffO",
-      "description": "Generated test vector #651",
-      "expected": [
-        "renown",
-        "potato",
-        "empower",
-        "pilot",
-        "hugs"
-      ]
-    },
-    {
-      "address": "IkkD8dzzTjA40InJ9CzyZG8VaaQUaUK",
-      "description": "Generated test vector #652",
-      "expected": [
-        "sunset",
-        "story",
-        "total",
-        "warm",
-        "forest"
-      ]
-    },
-    {
-      "address": "0xcpGdNUzSVU6ncXXRJ3FqqjRASH15kzdDr1YyBAyPfLjg9qDv1Ymuijl8",
-      "description": "Generated test vector #653",
-      "expected": [
-        "efficient",
-        "staunch",
-        "enter",
-        "cruise",
-        "spread"
-      ]
-    },
-    {
-      "address": "5dhUP4v7xBoLSc9UYWcxuAvOqyDhvIDNKbSwZnSVLmiA",
-      "description": "Generated test vector #654",
-      "expected": [
-        "screen",
-        "won",
-        "border",
-        "alone",
-        "satisfy"
-      ]
-    },
-    {
-      "address": "bc1qiHwyVVoiW1nPlUmcYSZTSdHKim6cUamoVQNHYnryVf",
-      "description": "Generated test vector #655",
-      "expected": [
-        "blessing",
-        "zen",
-        "claim",
-        "prosper",
-        "esteem"
-      ]
-    },
-    {
-      "address": "osmo13MaCBKXNx5QDAOH3OxwRtTQfERXCPAbmjZm88AGMq7GINJnC4D4P1Qex",
-      "description": "Generated test vector #656",
-      "expected": [
-        "poppy",
-        "eminence",
-        "indoor",
-        "seminar",
-        "tranquil"
-      ]
-    },
-    {
-      "address": "bc1qfFUZAvwfQbuyA4OzPcOnszfsJQAiKSfTout1",
-      "description": "Generated test vector #657",
-      "expected": [
-        "lady",
-        "nimble",
-        "ice",
-        "hub",
-        "pair"
-      ]
-    },
-    {
-      "address": "5juJy4BmPzKpuKaIvWrwWOmDFndTfPT66xxQ8vyX",
-      "description": "Generated test vector #658",
-      "expected": [
-        "jaguar",
-        "seek",
-        "taxi",
-        "subway",
-        "scene"
-      ]
-    },
-    {
-      "address": "bc1qkTrFqn8AyXJcaIASTUm1jt5BV2MmDww6f9XWM",
-      "description": "Generated test vector #659",
-      "expected": [
-        "pet",
-        "core",
-        "popular",
-        "economy",
-        "violin"
-      ]
-    },
-    {
-      "address": "0xE4s6RPNIavEpqAJs4XQ8HV2UW6uFJOyv9IBXsBfG",
-      "description": "Generated test vector #660",
-      "expected": [
-        "brief",
-        "wing",
-        "approve",
-        "now",
-        "voice"
-      ]
-    },
-    {
-      "address": "oBpqcYFMFyUdoFJKPrX7k5s2wGKkgYQyYFdGcutMxasXnyBCTKO2Alhu9oJQR8",
-      "description": "Generated test vector #661",
-      "expected": [
-        "tongue",
-        "idyllic",
-        "prolific",
-        "special",
-        "radio"
-      ]
-    },
-    {
-      "address": "SSRN3cWstLnx0zSygntUVbKWDWa92e1Y1fH4Ix4YLLVh4MScwhfYYn5z",
-      "description": "Generated test vector #662",
-      "expected": [
-        "letter",
-        "best",
-        "join",
-        "vouch",
-        "notable"
-      ]
-    },
-    {
-      "address": "qzkFXEDHNLj0RU604709b4RLf7nYemJkiI6",
-      "description": "Generated test vector #663",
-      "expected": [
-        "enhance",
-        "sword",
-        "purity",
-        "page",
-        "pear"
-      ]
-    },
-    {
-      "address": "cosmos1P6ZDP6DwIxSpaye46lz8icody",
-      "description": "Generated test vector #664",
-      "expected": [
-        "dew",
-        "radar",
-        "palace",
-        "winner",
-        "mirror"
-      ]
-    },
-    {
-      "address": "osmo1AEfgIcNH3PiPNoQ05mlw2FESiAjhr",
-      "description": "Generated test vector #665",
-      "expected": [
-        "blessing",
-        "adopt",
-        "chuckle",
-        "audit",
-        "culture"
-      ]
-    },
-    {
-      "address": "osmo1IQR9Y02RNJzH7wvfidnAGzqgQIapXzcHeL4pXIoAur2bzKYTZ4cZ",
-      "description": "Generated test vector #666",
-      "expected": [
-        "circle",
-        "wood",
-        "reclaim",
-        "lavender",
-        "rose"
-      ]
-    },
-    {
-      "address": "qzkvAIQN4vOEi8eiMaMC1O4l0PMrzyfLvcy1ri8yDsS3t4",
-      "description": "Generated test vector #667",
-      "expected": [
-        "lion",
-        "delectable",
-        "vivid",
-        "need",
-        "inform"
-      ]
-    },
-    {
-      "address": "3iY7fVxVHAVtGq62KNWzOhwjEEQcdw57mSjjlmjZycGUGML2Cg7dVa",
-      "description": "Generated test vector #668",
-      "expected": [
-        "candy",
-        "retire",
-        "tooth",
-        "sober",
-        "wide"
-      ]
-    },
-    {
-      "address": "osmo1uVlhq4bLZoPphShL25J43ogY4Ne1YHWFq41QN2D",
-      "description": "Generated test vector #669",
-      "expected": [
-        "idea",
-        "trivial",
-        "candy",
-        "adorable",
-        "inestimable"
-      ]
-    },
-    {
-      "address": "QsUfh5jfE613GFO7XJjt8vCVUAnuFCr6vhnRF6i",
-      "description": "Generated test vector #670",
-      "expected": [
-        "evocative",
-        "cohere",
-        "duty",
-        "real",
-        "leaf"
-      ]
-    },
-    {
-      "address": "qzktslNmh38QUIu9pwIGFDaqyA4RHH8sRZBSiMt",
-      "description": "Generated test vector #671",
-      "expected": [
-        "assume",
-        "silent",
-        "become",
-        "patch",
-        "garden"
-      ]
-    },
-    {
-      "address": "1SywlxUihOc0S6p7nNhXf5wK1xsRt5nKLDYQwoprJBM",
-      "description": "Generated test vector #672",
-      "expected": [
-        "convince",
-        "mint",
-        "extra",
-        "brisk",
-        "more"
-      ]
-    },
-    {
-      "address": "qzkfUUXssLETHwIzeGFZDz69YiwKEpC",
-      "description": "Generated test vector #673",
-      "expected": [
-        "fire",
-        "laud",
-        "sophisticated",
-        "chef",
-        "everlasting"
-      ]
-    },
-    {
-      "address": "bc1qh3Kc5njl1tI5Brmht6T3nyCCSEabyz9Vya7xSk90h7WNhK51F1HDWViqXL",
-      "description": "Generated test vector #674",
-      "expected": [
-        "puppy",
-        "shoe",
-        "follow",
-        "regal",
-        "news"
-      ]
-    },
-    {
-      "address": "bc1q4SwKZJPcyOy3H9fmOq9GTJ9f7O",
-      "description": "Generated test vector #675",
-      "expected": [
-        "machine",
-        "lesson",
-        "impeccable",
-        "lizard",
-        "laud"
-      ]
-    },
-    {
-      "address": "5g7lbyoIfUbITnxMGfzuvw9IMx5kMEU5m0lQuEECGDwmWAmWfpKK",
-      "description": "Generated test vector #676",
-      "expected": [
-        "spirit",
-        "shell",
-        "expect",
-        "behave",
-        "gospel"
-      ]
-    },
-    {
-      "address": "bc1q7OXlW1lLaY0h1cengt7tlm8Eje9",
-      "description": "Generated test vector #677",
-      "expected": [
-        "journey",
-        "thumb",
-        "humor",
-        "landmark",
-        "list"
-      ]
-    },
-    {
-      "address": "0xaT6g5W4pCLtMXL7v4nPbC6xPylcPhXVCA",
-      "description": "Generated test vector #678",
-      "expected": [
-        "popular",
-        "install",
-        "switch",
-        "fitness",
-        "vigor"
-      ]
-    },
-    {
-      "address": "bc1qdFxJ834MDPUw4BmVEahuQf7PmYT0a7AvFQ1QA",
-      "description": "Generated test vector #679",
-      "expected": [
-        "century",
-        "anchor",
-        "fashion",
-        "tortoise",
-        "pink"
-      ]
-    },
-    {
-      "address": "15GPD6F9DZ5KZ649zqEkmE0O2Vvy2quB",
-      "description": "Generated test vector #680",
-      "expected": [
-        "stock",
-        "record",
-        "strong",
-        "video",
-        "well"
-      ]
-    },
-    {
-      "address": "5MYN8Uv0Yo041OSibwBkOIqZGy2Nq2oXvI6VDaonTxylShzx8GRrWD",
-      "description": "Generated test vector #681",
-      "expected": [
-        "scout",
-        "genuine",
-        "stomach",
-        "fiery",
-        "between"
-      ]
-    },
-    {
-      "address": "qzkdXrvSxk9pbgX2zG1CKm35COq8W31Up074mWMqujd",
-      "description": "Generated test vector #682",
-      "expected": [
-        "list",
-        "often",
-        "discover",
-        "wood",
-        "exemplar"
-      ]
-    },
-    {
-      "address": "cosmos1dflEcXg2uy8q2DNmmoZAqnt1xRD",
-      "description": "Generated test vector #683",
-      "expected": [
-        "repeat",
-        "ecstatic",
-        "spoon",
-        "gripping",
-        "timber"
-      ]
-    },
-    {
-      "address": "bc1qbYvUNlbVbzGuUdf0RQhjl2yfnglCwNGsPR74pzFa4F8EecX",
-      "description": "Generated test vector #684",
-      "expected": [
-        "segment",
-        "boss",
-        "tonight",
-        "imitate",
-        "invulnerable"
-      ]
-    },
-    {
-      "address": "5hbAccCmHOBTFmap0vn5urQ12MDFMl1IYpPy9p6AUuMZ693IO39Kb",
-      "description": "Generated test vector #685",
-      "expected": [
-        "cradle",
-        "boat",
-        "system",
-        "ticket",
-        "quote"
-      ]
-    },
-    {
-      "address": "3C3B0ZjMWhwm4ci6OymbL34w7v88bLKX",
-      "description": "Generated test vector #686",
-      "expected": [
-        "gesture",
-        "frolic",
-        "monkey",
-        "plentiful",
-        "wink"
-      ]
-    },
-    {
-      "address": "cosmos1XQmkh1Mwf8ubhe6ic905h4s2Wc",
-      "description": "Generated test vector #687",
-      "expected": [
-        "wave",
-        "genre",
-        "pencil",
-        "script",
-        "witness"
-      ]
-    },
-    {
-      "address": "bc1q4vGRnGBZL2KGUqSNuGg1HE1lFi50K",
-      "description": "Generated test vector #688",
-      "expected": [
-        "authentic",
-        "vault",
-        "dose",
-        "dish",
-        "guard"
-      ]
-    },
-    {
-      "address": "1v1wCzGGSuucdFJT0M0qFyPuZVFrT20TFipzsouB0KwWLX5wuF1FSPBWsVCEEx",
-      "description": "Generated test vector #689",
-      "expected": [
-        "pear",
-        "sincere",
-        "flexible",
-        "cruise",
-        "walk"
-      ]
-    },
-    {
-      "address": "3rRhFjrKYDDcES23LrZJTCqS3BiQvA0huKvbkBBMXxhjWjjDwX6Y6",
-      "description": "Generated test vector #690",
-      "expected": [
-        "people",
-        "sort",
-        "seminar",
-        "kiwi",
-        "suave"
-      ]
-    },
-    {
-      "address": "bc1qg4Ndv7uorw73wAlh97PmX5D8VzdYLVsXJbzSsef4QIV",
-      "description": "Generated test vector #691",
-      "expected": [
-        "utility",
-        "royal",
-        "canal",
-        "woman",
-        "redeemed"
-      ]
-    },
-    {
-      "address": "1KnI3WM71PAG728HObfwWILfwmczdLlQonJpKlaPoIBkO7IMGr6GUzCzUq0",
-      "description": "Generated test vector #692",
-      "expected": [
-        "mushroom",
-        "stellar",
-        "elan",
-        "lawsuit",
-        "decrypt"
-      ]
-    },
-    {
-      "address": "3HsRllVADjYt0pOmQkEYzBWufQDZsL",
-      "description": "Generated test vector #693",
-      "expected": [
-        "strong",
-        "fork",
-        "north",
-        "exotic",
-        "inhale"
-      ]
-    },
-    {
-      "address": "3yBf5pYnXMufuYzOmr6MXKaIJxVKyPYd3OH0JXpVN2ixEldCo",
-      "description": "Generated test vector #694",
-      "expected": [
-        "fog",
-        "grass",
-        "health",
-        "immense",
-        "thing"
-      ]
-    },
-    {
-      "address": "dxSmz5R97Ep5WuxX3PByY48ZCxPdveT4NDAN6q84kczpAlp",
-      "description": "Generated test vector #695",
-      "expected": [
-        "depart",
-        "top",
-        "noble",
-        "spatial",
-        "capital"
-      ]
-    },
-    {
-      "address": "cosmos1csfQApS1ipfJJGPOXzMot0tHM94ZRF53z9",
-      "description": "Generated test vector #696",
-      "expected": [
-        "aunt",
-        "icon",
-        "humility",
-        "dose",
-        "list"
-      ]
-    },
-    {
-      "address": "3PQcrmHac8XMeZcwhfqCZW4JVwLuiblMA7Xn4Fmt1MD3ShceKj3iyKrXmCrB7",
-      "description": "Generated test vector #697",
-      "expected": [
-        "ingenious",
-        "comfort",
-        "stout",
-        "derive",
-        "actual"
-      ]
-    },
-    {
-      "address": "3rfhrXlAv1kmfzwFzjCujCidpNDdCta3",
-      "description": "Generated test vector #698",
-      "expected": [
-        "pave",
-        "stamp",
-        "machine",
-        "gorgeous",
-        "camp"
-      ]
-    },
-    {
-      "address": "osmo1IcJt7V8fG0CQmloXlXV4b1qrKtf1uY3Kl1RojkQzGu5ugbSs1OeS",
-      "description": "Generated test vector #699",
-      "expected": [
-        "leopard",
-        "away",
-        "uplift",
-        "lesson",
-        "youth"
-      ]
-    },
-    {
-      "address": "ctdnrWSnzVaDVRlRdJHrz9o5cOfCZUBglR2k3Znn4YUfN0xGCLxvf7oQIbR8QS",
-      "description": "Generated test vector #700",
-      "expected": [
-        "runway",
-        "canal",
-        "decent",
-        "reputable",
-        "sovereign"
-      ]
-    },
-    {
-      "address": "1LHpOEn3rEGSpsxRXs9wjTJ5wbE6xwJy1D2tj6lgPjbh5NxT7hB1bh",
-      "description": "Generated test vector #701",
-      "expected": [
-        "view",
-        "snack",
-        "gain",
-        "dauntless",
-        "walnut"
-      ]
-    },
-    {
-      "address": "bc1qZKerJYeCdmiQPGv0PQCZ0WfPCRF2gIAOT4sbEmtKyXQ9YjvY08wo5",
-      "description": "Generated test vector #702",
-      "expected": [
-        "illuminate",
-        "surge",
         "across",
-        "physical",
-        "staff"
-      ]
-    },
-    {
-      "address": "qzkTWLvdwAU2SzDwhihTqB8ELx95P6OtHxLKUlicemR3AJjY",
-      "description": "Generated test vector #703",
-      "expected": [
-        "frolic",
-        "cure",
-        "human",
-        "grit",
-        "fork"
-      ]
-    },
-    {
-      "address": "1J7JnocMpIIcNGFTWxo0lQdLrIEDhljKPmU",
-      "description": "Generated test vector #704",
-      "expected": [
-        "equal",
-        "nominee",
-        "dream",
-        "upside",
-        "rapid"
-      ]
-    },
-    {
-      "address": "1o8XinBCA4apOQYBZNduDOSWICm4PnNmp5eQEbK3CdqcWxRxN9lLmJzxZC",
-      "description": "Generated test vector #705",
-      "expected": [
-        "surge",
-        "rose",
-        "bulb",
-        "merkle",
-        "program"
-      ]
-    },
-    {
-      "address": "0xHuyVo5NqXdSajEUDMv0j5a0XF2ML6Nnj0MpB7ntFNguE1swdf8z02klZuuzk4",
-      "description": "Generated test vector #706",
-      "expected": [
-        "panic",
-        "exhibit",
-        "amateur",
-        "thunder",
-        "session"
-      ]
-    },
-    {
-      "address": "1vpyRkPJaZfBPox44X5ZqQSddX5G9dJVgliqVfk4kNEy",
-      "description": "Generated test vector #707",
-      "expected": [
-        "tiny",
-        "halcyon",
-        "join",
-        "crumb",
-        "hollow"
-      ]
-    },
-    {
-      "address": "5cLBPfT4qlPAwXiv6Xe4R2IBLPTIJRlXKkY1NgrJ4qggafY7QyJlh0zj4ZYbB3",
-      "description": "Generated test vector #708",
-      "expected": [
-        "brother",
-        "lift",
-        "outdoor",
-        "homage",
-        "lavish"
-      ]
-    },
-    {
-      "address": "3MFstMF7ywseHC6Lpx2uLgz7RJ97ljhO3",
-      "description": "Generated test vector #709",
-      "expected": [
-        "oyster",
-        "head",
-        "dog",
-        "plate",
-        "bachelor"
-      ]
-    },
-    {
-      "address": "1dtigy2V3olpSah225y6DfpWaipZUpoAXYDbVMTONO",
-      "description": "Generated test vector #710",
-      "expected": [
-        "bounty",
-        "ride",
-        "cash",
-        "carry",
-        "salute"
-      ]
-    },
-    {
-      "address": "N4AyDdH21EicOlsQbZR2weQYUSE4rC8vlv2BY9Kml9ASUSKtlIgIXFlxlPkZI",
-      "description": "Generated test vector #711",
-      "expected": [
-        "crystal",
-        "suffice",
-        "series",
-        "behave",
-        "badge"
-      ]
-    },
-    {
-      "address": "5b2Tcl2v4VoGLJeeAJlflpRSvY89aDaI43JOLXyWCFRzVo5Y4wLZITrk3Kum0lc",
-      "description": "Generated test vector #712",
-      "expected": [
-        "god",
-        "oak",
-        "level",
-        "select",
-        "inherit"
-      ]
-    },
-    {
-      "address": "osmo1vfzOv5R4bztgo15oUTa0TpEE5ioi1",
-      "description": "Generated test vector #713",
-      "expected": [
-        "book",
-        "meaningful",
-        "huge",
-        "bottom",
-        "winner"
-      ]
-    },
-    {
-      "address": "qzkWC7cR2ZkNHiedXGMSUv1PT0tiYejU6AUEYes0m9gbHy8dAVWKqZbYHFbRs7",
-      "description": "Generated test vector #714",
-      "expected": [
-        "want",
-        "organ",
-        "twin",
-        "saddle",
-        "october"
-      ]
-    },
-    {
-      "address": "14hFsRbfcG8dNDBXlVrLD4aP7rNPpSti",
-      "description": "Generated test vector #715",
-      "expected": [
-        "fire",
-        "alpha",
-        "hamster",
-        "what",
-        "solution"
-      ]
-    },
-    {
-      "address": "0xw1XsyeMghuuUJiSV9Qho7A1QifxWSXLV6IS4ZEDBxdFCeWLf8nCNjr",
-      "description": "Generated test vector #716",
-      "expected": [
-        "violin",
-        "grab",
-        "night",
-        "authentic",
-        "praise"
-      ]
-    },
-    {
-      "address": "qzkcwKtTzFZOXZnhIQE8OWTcMXvEtulJVHuPSc3ZLVKB",
-      "description": "Generated test vector #717",
-      "expected": [
-        "cash",
-        "crucial",
-        "snazzy",
-        "marble",
-        "abundance"
-      ]
-    },
-    {
-      "address": "osmo1bzG03a8T7ewCOlQvQvuntrVcV4RQCRFG8K2N3i8g5",
-      "description": "Generated test vector #718",
-      "expected": [
-        "deliver",
-        "where",
-        "agent",
-        "proud",
         "possible"
       ]
     },
     {
-      "address": "0xWQarVME89WsgBPHa6f379Izfz6jAVs6ERIzfX8FCapuWQOnUCi0OVJMD3",
-      "description": "Generated test vector #719",
+      "address": "bc1qyvsXiL2F0HtTInnSQ5iS8lHNSVIK6SP3H2AagxddqW8",
+      "description": "Generated test vector #78",
       "expected": [
-        "during",
-        "tomato",
-        "celebrate",
-        "dog",
-        "park"
-      ]
-    },
-    {
-      "address": "0xNdXo8XBKT5Jq0jCrGg5lfA8ppY5QYgWkwfYdppVqT",
-      "description": "Generated test vector #720",
-      "expected": [
-        "impressed",
-        "blade",
-        "egg",
-        "speed",
-        "pizza"
-      ]
-    },
-    {
-      "address": "33XDbY7QnifOjhYpNhZ3NbagTOmWwhePqOA5O6UwmqiWhZgQPMSt",
-      "description": "Generated test vector #721",
-      "expected": [
-        "ghost",
-        "crane",
-        "sophisticated",
-        "crumb",
-        "angle"
-      ]
-    },
-    {
-      "address": "3XfrZtBV2HjGSMdg0J0tbXivwovdmP5uNFbbXt2SFK2NBnqWsilRDEpW",
-      "description": "Generated test vector #722",
-      "expected": [
-        "aunt",
-        "spirit",
-        "buyer",
-        "paper",
-        "during"
-      ]
-    },
-    {
-      "address": "cosmos1qKcAYdaJ25yHhTCXXEKWYI31OxKib0bjwYvmAfAJ90YiNpb",
-      "description": "Generated test vector #723",
-      "expected": [
-        "shimmering",
-        "that",
-        "divide",
-        "ratified",
-        "easy"
-      ]
-    },
-    {
-      "address": "37w6XRshydidZU8WsPL5qqjIwQpf0Kqzq5sR3SvCFhBlgRrTOiTGiiQ",
-      "description": "Generated test vector #724",
-      "expected": [
-        "safe",
-        "crush",
-        "witness",
-        "yak",
-        "toy"
-      ]
-    },
-    {
-      "address": "0xn7yPiyC4qbP8r5uwfIoehaai1iSkDOQuwX586B",
-      "description": "Generated test vector #725",
-      "expected": [
-        "surprise",
-        "come",
-        "fresh",
-        "mature",
-        "impeccable"
-      ]
-    },
-    {
-      "address": "5DqmnRnUY9CTiB7LVJe7haxEUemMp9G7JW85v2e3DgblIIeCbY9dM0C04giDl",
-      "description": "Generated test vector #726",
-      "expected": [
-        "volume",
-        "undeniable",
-        "quote",
-        "sea",
-        "theme"
-      ]
-    },
-    {
-      "address": "cosmos1UGd8jQP9LZRGzSadjbOD26hKUrlK",
-      "description": "Generated test vector #727",
-      "expected": [
-        "attitude",
-        "chef",
-        "encrypt",
-        "bridge",
-        "affluence"
-      ]
-    },
-    {
-      "address": "osmo1VinYY43FCvCBMmmYIHX12reukXr65cFHEvREvH6avUscM4kpzsy",
-      "description": "Generated test vector #728",
-      "expected": [
-        "chat",
-        "affluence",
-        "mountain",
-        "swim",
-        "fancy"
-      ]
-    },
-    {
-      "address": "qzkF7g4rQcX4OqP4QQ4jExP5LmJrA26UxpcIQPRIT",
-      "description": "Generated test vector #729",
-      "expected": [
-        "lava",
-        "detail",
-        "shuffle",
-        "clarify",
-        "night"
-      ]
-    },
-    {
-      "address": "osmo1tqeUdO6CjA6FMOBLtCd7rn0AqPL95qp6HqacMmvXZxWlARKUZV6n8SDmvEi",
-      "description": "Generated test vector #730",
-      "expected": [
-        "forward",
-        "answer",
-        "auction",
-        "cohere",
-        "confirm"
-      ]
-    },
-    {
-      "address": "599jpbWCFJWhoRlWxaHSa24YnOc7b3qY8YzOhFA6q3L11XYbEccE6gro2bdr",
-      "description": "Generated test vector #731",
-      "expected": [
-        "uphold",
-        "paper",
-        "wide",
-        "water",
-        "room"
-      ]
-    },
-    {
-      "address": "193ryBON0xFRB243RXZTpxFAGsHEekF2MpSLFkmqJfjmn1ZG04hIbCYn8PaS6",
-      "description": "Generated test vector #732",
-      "expected": [
-        "gossip",
-        "all",
-        "surface",
-        "planet",
-        "unwavering"
-      ]
-    },
-    {
-      "address": "cosmos1A5DwZqTCRyszKofgQTwOEWPBY5YSx1DyIhFTvNKt25ewr",
-      "description": "Generated test vector #733",
-      "expected": [
-        "hire",
-        "brown",
-        "gain",
-        "choice",
-        "nurse"
-      ]
-    },
-    {
-      "address": "EiIEiwTiaeRwc3kZCQOAQcxDs1AKpXfpmHlJ3obe5XFPypGvExRwJgelL6vRGt6",
-      "description": "Generated test vector #734",
-      "expected": [
-        "enroll",
-        "resemble",
-        "sea",
-        "razor",
-        "copy"
-      ]
-    },
-    {
-      "address": "OC5Ou874A2Om0SJSUBpCHi6xchMKgYTh15tDRkmXQH",
-      "description": "Generated test vector #735",
-      "expected": [
-        "alter",
-        "torch",
-        "very",
-        "water",
-        "album"
-      ]
-    },
-    {
-      "address": "3Gwh7CAJZ2dYaO50YLdWM1T1Zl7CghWXNJN3TxZYSzlcyAnXL9vGrTxuP",
-      "description": "Generated test vector #736",
-      "expected": [
-        "hooray",
+        "equip",
+        "never",
+        "grin",
         "truly",
-        "runway",
-        "very",
-        "carefree"
+        "rapport"
       ]
     },
     {
-      "address": "1adEt1UZeqjirsUvEwVUn16F1N2LCiqsWf4aEPkQRo5UENn",
-      "description": "Generated test vector #737",
+      "address": "cosmos10QsUcYg1T1UIoWXrP5y78tIapMW1Z4RO",
+      "description": "Generated test vector #79",
       "expected": [
-        "embody",
-        "elephant",
-        "crisp",
-        "swim",
-        "picnic"
-      ]
-    },
-    {
-      "address": "5vBehw6ut5r6lyAvQJXJ1LlRZ7v5g2ZnpdjMT8NulrBlRZei11n4",
-      "description": "Generated test vector #738",
-      "expected": [
-        "shiver",
-        "vehicle",
-        "burden",
-        "toe",
-        "top"
-      ]
-    },
-    {
-      "address": "19vpRwC56XfTAP8c5yOPLcSZlpnqpZUIXKpjV5a",
-      "description": "Generated test vector #739",
-      "expected": [
-        "immortal",
-        "utility",
-        "tops",
-        "calm",
-        "clinic"
-      ]
-    },
-    {
-      "address": "0xNk3BSojF0F2BHPgLnHxcccdANiF1ODBuyIhkO7OorAnlrxO8P1G6VuUTu",
-      "description": "Generated test vector #740",
-      "expected": [
-        "offer",
-        "motor",
-        "wheel",
-        "aim",
-        "release"
-      ]
-    },
-    {
-      "address": "qzkEt9e9wW0EJxRJ4zWaWNV5RBtl0TFNfIl3uTuDKwSCiEzqr6",
-      "description": "Generated test vector #741",
-      "expected": [
-        "feel",
-        "pool",
-        "sweet",
-        "aspect",
-        "hip"
-      ]
-    },
-    {
-      "address": "cosmos1dMDHnElIhMmNj3PLkNcSP6syiqCAOKuL5D5O",
-      "description": "Generated test vector #742",
-      "expected": [
-        "trivial",
-        "return",
-        "curious",
-        "alter",
-        "connect"
-      ]
-    },
-    {
-      "address": "cosmos1yQb6BjsAyLQn5YQJtGF2U4buJuNkDlxUjYWuTjp6S25YLk7TqkWQpp",
-      "description": "Generated test vector #743",
-      "expected": [
-        "noodle",
-        "adventurous",
-        "pet",
-        "wild",
-        "kind"
-      ]
-    },
-    {
-      "address": "5ycg7LUfcxFkYxTGGD87qp3pbp5VPMf7MuXoscIHRogpbyTqAeiZ4EE8",
-      "description": "Generated test vector #744",
-      "expected": [
-        "embrace",
-        "raw",
-        "maze",
-        "hail",
-        "vault"
-      ]
-    },
-    {
-      "address": "bc1qfPj5bxfVlajJwn5pZNQQsaIeEl",
-      "description": "Generated test vector #745",
-      "expected": [
-        "tolerant",
-        "medal",
-        "close",
-        "state",
-        "brown"
-      ]
-    },
-    {
-      "address": "1EcgML36gVEt4RaRQONUeC102Yksto9WFWh4tSsMh8dSIaDHlcpco9Sa1",
-      "description": "Generated test vector #746",
-      "expected": [
-        "also",
-        "night",
-        "divide",
-        "seat",
-        "choose"
-      ]
-    },
-    {
-      "address": "bc1qMJhZkxQb11nqeoQUlBjj12fgBISk7UkxQgUyFhA5XUzi",
-      "description": "Generated test vector #747",
-      "expected": [
-        "popular",
-        "cave",
-        "dog",
-        "universe",
-        "route"
-      ]
-    },
-    {
-      "address": "0xtuF2UAoakMsDY6m1rPwmLrePbttGFks5BoEpCET",
-      "description": "Generated test vector #748",
-      "expected": [
-        "because",
-        "describe",
-        "mushroom",
-        "such",
-        "bundle"
-      ]
-    },
-    {
-      "address": "9OyOZvFtSaEkkN8pSIJhQ4iwfjZpAmxb2KwlcteDSq6X",
-      "description": "Generated test vector #749",
-      "expected": [
-        "now",
-        "eminence",
-        "point",
-        "gecko",
-        "carpet"
-      ]
-    },
-    {
-      "address": "1dyH61J4I7Nf3WpdTLtsQ6HOhdh96r4RERCze1iITfcjfAu5D6Vc2PIp97s",
-      "description": "Generated test vector #750",
-      "expected": [
-        "abundance",
-        "prowess",
-        "delectable",
-        "spare",
-        "plentiful"
-      ]
-    },
-    {
-      "address": "BOuljMvKQGGIWwFkCkL6nSR3Mk3bYpFPmLGVrriC",
-      "description": "Generated test vector #751",
-      "expected": [
-        "cousin",
-        "astound",
-        "history",
-        "verify",
-        "plus"
-      ]
-    },
-    {
-      "address": "tVXvSLIIPzWjp81Z136NdgApWhQixQpQv8zyXGA2mCrq",
-      "description": "Generated test vector #752",
-      "expected": [
-        "volume",
-        "winter",
-        "cousin",
-        "walnut",
-        "marble"
-      ]
-    },
-    {
-      "address": "osmo1T26m25fgv3q9uNkYNGs1VxF3eMh4qEL3",
-      "description": "Generated test vector #753",
-      "expected": [
-        "wealth",
-        "play",
-        "squeeze",
-        "formidable",
-        "marvel"
-      ]
-    },
-    {
-      "address": "5lKFBpTuOMGEVJhoaCYq8OXnr2lQovC3kumeSfp84oDNZxkm",
-      "description": "Generated test vector #754",
-      "expected": [
-        "add",
-        "caught",
-        "prudence",
-        "honey",
-        "valor"
-      ]
-    },
-    {
-      "address": "0x5NaAUySx1MpBtgYXXGE7MxaeVBvagkaT",
-      "description": "Generated test vector #755",
-      "expected": [
-        "nice",
-        "turkey",
-        "enter",
-        "cake",
-        "barrel"
-      ]
-    },
-    {
-      "address": "bc1qzapd4DIYHW7Foi5dyeUMsx0MVMYUC2k",
-      "description": "Generated test vector #756",
-      "expected": [
-        "blanket",
-        "diagram",
-        "soothe",
-        "green",
-        "morning"
-      ]
-    },
-    {
-      "address": "0xrrqpaD0kRHASvwG5tL1q8ORnUEVFKbtD",
-      "description": "Generated test vector #757",
-      "expected": [
-        "gutsy",
-        "second",
-        "jazz",
-        "runway",
-        "sun"
-      ]
-    },
-    {
-      "address": "qzk0mBatMcKLTHtVYodo8AbiwIzNxS0zwP4y4ufkdFikitO4G2irKdvWNtxuXNDC",
-      "description": "Generated test vector #758",
-      "expected": [
-        "intuitive",
-        "viable",
-        "culture",
-        "observe",
-        "ask"
-      ]
-    },
-    {
-      "address": "osmo1ZSzQwVCn2pYXv5jekuYIsCKNfEu",
-      "description": "Generated test vector #759",
-      "expected": [
-        "dinner",
-        "beach",
-        "drive",
-        "vivid",
-        "comic"
-      ]
-    },
-    {
-      "address": "30KNkqQ0A2mMEQK6MiYPvcaIVvS6rzTDtZHe9PLD",
-      "description": "Generated test vector #760",
-      "expected": [
-        "truly",
-        "volume",
-        "cherry",
-        "actual",
-        "stage"
-      ]
-    },
-    {
-      "address": "bc1qjreiAkqFiypqzeLGlilxvLZOQcg7ef2x9mZXoFxrGsAXAPP",
-      "description": "Generated test vector #761",
-      "expected": [
-        "letter",
-        "focus",
-        "correct",
-        "patient",
-        "clump"
-      ]
-    },
-    {
-      "address": "bc1qn4HTQeJ5E85ECCozVCtvu2m3FMXRmVS",
-      "description": "Generated test vector #762",
-      "expected": [
-        "diplomat",
-        "fascinate",
-        "mint",
-        "note",
-        "gecko"
-      ]
-    },
-    {
-      "address": "1iMJxodMUlpO2mQ8tOtUbbxbiXaBSt9Us",
-      "description": "Generated test vector #763",
-      "expected": [
-        "attend",
-        "ingenious",
-        "prolific",
-        "lemon",
-        "rich"
-      ]
-    },
-    {
-      "address": "Bg687Ip9OC23CdKdJZ4vPjTWwMCVjHHGVLfPZK7ZwfQuKURrZy99AViZap8k",
-      "description": "Generated test vector #764",
-      "expected": [
-        "rapport",
-        "reward",
-        "oblige",
-        "boil",
-        "boat"
-      ]
-    },
-    {
-      "address": "3xHuEaeKVLvc3sBc5QoEV74U4RdQPC3cNoRAPggPaEMXUxqD0ErlF521VUE3ufw",
-      "description": "Generated test vector #765",
-      "expected": [
-        "draw",
-        "fruit",
-        "pattern",
-        "head",
-        "awesome"
-      ]
-    },
-    {
-      "address": "0x4y6ewDQwzz1z938JAUyzaJwhz1emu9lqxejyzKfjR4BTt0RyEsDUFLz",
-      "description": "Generated test vector #766",
-      "expected": [
-        "two",
-        "any",
-        "canvas",
-        "core",
-        "well"
-      ]
-    },
-    {
-      "address": "bc1qJ5dkMqmJZlVYTAiahDz4Vgy8UfZ1p9O",
-      "description": "Generated test vector #767",
-      "expected": [
-        "elbow",
-        "right",
-        "limb",
-        "peanut",
-        "meadow"
-      ]
-    },
-    {
-      "address": "PoyAjlzvDNvCyTkLteX2ZSnUDbUtGRsRxUuQovzhFUap8a01PSuPz",
-      "description": "Generated test vector #768",
-      "expected": [
-        "broccoli",
-        "else",
-        "source",
-        "dextrous",
-        "grass"
-      ]
-    },
-    {
-      "address": "3ImOPdgOkVCXb6NAyySMDFOj7uFul8EdkP",
-      "description": "Generated test vector #769",
-      "expected": [
-        "embrace",
-        "exotic",
-        "domain",
-        "resilient",
-        "edge"
-      ]
-    },
-    {
-      "address": "cosmos1ZEnNmUOjpv0BQzZKvYZTdyCd",
-      "description": "Generated test vector #770",
-      "expected": [
-        "grow",
-        "wieldy",
-        "staunch",
-        "element",
-        "lit"
-      ]
-    },
-    {
-      "address": "1RVur0sHewXLFF344ehKBzJpTzvzvF97RXx0OO",
-      "description": "Generated test vector #771",
-      "expected": [
-        "brush",
-        "pave",
-        "sudden",
-        "valor",
-        "lovable"
-      ]
-    },
-    {
-      "address": "0xIIqWl0YTtDYzySoH0vvW74RKfwvyBl6IOTV7",
-      "description": "Generated test vector #772",
-      "expected": [
-        "faultless",
-        "ready",
-        "pink",
-        "large",
-        "liquid"
-      ]
-    },
-    {
-      "address": "bc1qY5JrjCzgWPzREc6iPb1nNn6gea4MyD8B6mBspn3wDCgMaz1Er1",
-      "description": "Generated test vector #773",
-      "expected": [
-        "unparalleled",
-        "tranquil",
-        "hospital",
-        "before",
-        "stone"
-      ]
-    },
-    {
-      "address": "bc1qEcqYmpySa69qAIHUoOUGFHdjnf7XA2hqEFdcudafshtWVab4P75B",
-      "description": "Generated test vector #774",
-      "expected": [
-        "aid",
+        "panther",
         "prefer",
-        "amenity",
-        "resilient",
-        "resource"
+        "misery",
+        "survey",
+        "pepper"
       ]
     },
     {
-      "address": "6pBVotEpyJYNcLggG6xeng7vhONOSwef3OmvsUJkJdlJMTKToVpHBzD0cNZ0G6",
-      "description": "Generated test vector #775",
+      "address": "W7slQlkFxAIiKpuSjjud5MPEJwWtnleFzHfnnuwnUG",
+      "description": "Generated test vector #80",
       "expected": [
-        "ring",
-        "seed",
-        "merkle",
-        "correct",
-        "process"
+        "evolve",
+        "scan",
+        "industry",
+        "gripping",
+        "hallmark"
       ]
     },
     {
-      "address": "1WZbnL8IHrPObgmoQJmMQBaxxF2DvteunZgYFdBB0E",
-      "description": "Generated test vector #776",
+      "address": "hvoN4pc2xXhpSbGVFFEsOtff8VHMnN",
+      "description": "Generated test vector #81",
       "expected": [
-        "authentic",
-        "episode",
-        "snack",
-        "course",
-        "debris"
-      ]
-    },
-    {
-      "address": "3V2dj89tBcFUlQazxEDKNqLPkuUClzJz6RfUtC",
-      "description": "Generated test vector #777",
-      "expected": [
-        "such",
-        "lens",
-        "record",
-        "tender",
-        "main"
-      ]
-    },
-    {
-      "address": "3BsYQ6Gj1iz0L7RYwg5YtA3WHvtATEcwOU0G8HFmeKqudVt7d5sU",
-      "description": "Generated test vector #778",
-      "expected": [
-        "other",
-        "noodle",
-        "reflect",
-        "lizard",
-        "salamander"
-      ]
-    },
-    {
-      "address": "osmo1momHjs8wrtde12S06NyHaNX79T4CxPUyj5FNJCTDSl3nDmIOr",
-      "description": "Generated test vector #779",
-      "expected": [
-        "laud",
-        "purse",
-        "glisten",
-        "pledge",
-        "shine"
-      ]
-    },
-    {
-      "address": "URzf9lhLlJrVSk7nFR1V1loJ1fFrwdHkHG5oqa3vnm4FAlP2a8JU6wgZFS",
-      "description": "Generated test vector #780",
-      "expected": [
-        "stamp",
-        "screen",
-        "enter",
-        "lucrative",
-        "dank"
-      ]
-    },
-    {
-      "address": "3mWXdz0zHx7nBdQZ6kbkwBGXNy5PyembIyg",
-      "description": "Generated test vector #781",
-      "expected": [
-        "lava",
-        "expand",
-        "tone",
-        "navigable",
-        "cook"
-      ]
-    },
-    {
-      "address": "37jVom3tdZr2EJNA9pOn9c6d6gzVA98GwteUHuM56j3vVgatAcTVUTX",
-      "description": "Generated test vector #782",
-      "expected": [
-        "job",
-        "syrup",
+        "category",
         "kitten",
-        "prize",
-        "darling"
-      ]
-    },
-    {
-      "address": "33sKNBLuFNgZxY3r7zMHr92nZ4AdlQjnGmqpZCXNaCkFbpO9NU0AfH",
-      "description": "Generated test vector #783",
-      "expected": [
-        "resource",
-        "round",
-        "dove",
-        "quiet",
-        "vintage"
-      ]
-    },
-    {
-      "address": "bc1qOWEeCVwTeIXIkUJjYl73eWlF1Qi02HhYzAucudT9",
-      "description": "Generated test vector #784",
-      "expected": [
-        "protect",
-        "current",
-        "tolerant",
-        "gap",
-        "acclaim"
-      ]
-    },
-    {
-      "address": "3ULoLop7UwTkpyj8IFrc4680DypKKjTUTbnbzpfIOZKctb8",
-      "description": "Generated test vector #785",
-      "expected": [
         "dice",
-        "soccer",
-        "cohere",
-        "right",
-        "uplift"
+        "capable",
+        "ability"
       ]
     },
     {
-      "address": "cosmos11OubtI4CkddppJogeh60ampyQFr6yPEmsrxxaiyTV0XqjIHlGnNw1XQ",
-      "description": "Generated test vector #786",
+      "address": "bc1qZmZ2TAYeQbScelpeY4zBztyhaSdUc0wFrQLr5xYbjnUX0sNs271O7",
+      "description": "Generated test vector #82",
       "expected": [
-        "ticket",
-        "dust",
-        "zebra",
-        "affluence",
-        "rectified"
-      ]
-    },
-    {
-      "address": "cosmos1sKVhbyVu8xQAI65nTAyGCjZ",
-      "description": "Generated test vector #787",
-      "expected": [
-        "victory",
-        "process",
-        "unrivaled",
-        "autumn",
-        "bulb"
-      ]
-    },
-    {
-      "address": "ppxqL2FUnmM8owT2yGHvlXZ2r1fpYESCuT",
-      "description": "Generated test vector #788",
-      "expected": [
-        "depend",
-        "comfort",
-        "space",
-        "affection",
-        "age"
-      ]
-    },
-    {
-      "address": "bc1q1cV7c8CetZy1J6oxWbmQbD4y4Tfd1bYRE2AN3b14X3FXCCeS7JgtCo",
-      "description": "Generated test vector #789",
-      "expected": [
-        "great",
-        "unquestionable",
-        "exquisite",
-        "visa",
-        "pluck"
-      ]
-    },
-    {
-      "address": "bc1qVhq1BISB46xYRIe80Kh0VM0F4kJPd2bGgRPIuwCoRrCzh",
-      "description": "Generated test vector #790",
-      "expected": [
-        "moral",
-        "chase",
-        "muscle",
-        "savings",
-        "have"
-      ]
-    },
-    {
-      "address": "osmo1J8bYAMpH5fUadTcBzjW9dA8cVLjzTkIPuXj5UqKEZL3xXNKQ",
-      "description": "Generated test vector #791",
-      "expected": [
-        "chef",
-        "encrypt",
-        "doctor",
-        "lion",
-        "drum"
-      ]
-    },
-    {
-      "address": "5N29B6FZZR67pP440u8UiOKXQEhuSaND5Rp7jxXch3zyEvD9B92JRQgA",
-      "description": "Generated test vector #792",
-      "expected": [
-        "begin",
-        "formidable",
-        "observe",
-        "phone",
-        "suggest"
-      ]
-    },
-    {
-      "address": "osmo1zXs9CJLbsFNESCi10BivpeN9J",
-      "description": "Generated test vector #793",
-      "expected": [
-        "onion",
-        "split",
-        "joy",
-        "answer",
-        "spawn"
-      ]
-    },
-    {
-      "address": "osmo1tA2hzZxC3jOQBbRgSRcYyepR1DfiXPYSxA8raoNrMOQzJnnk7U4CPw3o7",
-      "description": "Generated test vector #794",
-      "expected": [
-        "ring",
-        "kingdom",
-        "young",
-        "gesture",
-        "kick"
-      ]
-    },
-    {
-      "address": "0xClnWBI5OxwZighB9vwEw7MxIG3qfVvPK0RKO5tyjytbxlPdfX",
-      "description": "Generated test vector #795",
-      "expected": [
-        "father",
-        "again",
-        "cabin",
-        "siren",
-        "stairs"
-      ]
-    },
-    {
-      "address": "qzkeKDGKnZkXq1YuOPMEQg6zfrxt6XAuji0X3VcPf9gGgKBMHc0L7",
-      "description": "Generated test vector #796",
-      "expected": [
-        "young",
-        "dextrous",
-        "window",
-        "point",
-        "maple"
-      ]
-    },
-    {
-      "address": "cosmos1BXsP4OY2Y3FE5pTGbFXLa04FHqlr0vc0gScx6n",
-      "description": "Generated test vector #797",
-      "expected": [
-        "cipher",
-        "announce",
-        "astute",
-        "vacuum",
-        "prolific"
-      ]
-    },
-    {
-      "address": "YKclgoezzsbiNj7sABAqFjQTJ1yjCYMZWq3SL0y1jpe0Uw8vS2VyE1Ffb",
-      "description": "Generated test vector #798",
-      "expected": [
-        "possible",
-        "soft",
-        "message",
-        "canoe",
-        "mist"
-      ]
-    },
-    {
-      "address": "osmo1s5JUsgqcx2RIuXihoDjqT84xflgn",
-      "description": "Generated test vector #799",
-      "expected": [
-        "embrace",
-        "gusto",
-        "ball",
-        "wife",
-        "resilient"
-      ]
-    },
-    {
-      "address": "osmo1EtyFauFJt7GwN50PDGJ5hkAxxmw4ziCQizoXDopHMLUvv9ZY",
-      "description": "Generated test vector #800",
-      "expected": [
-        "bone",
-        "flamingo",
-        "auction",
-        "million",
-        "swarm"
-      ]
-    },
-    {
-      "address": "0x4WY03b1EQbis1bUOJqnwnf2NRMbn6ThGZU71N3",
-      "description": "Generated test vector #801",
-      "expected": [
-        "diary",
-        "swank",
-        "pinnacle",
-        "stock",
-        "surprise"
-      ]
-    },
-    {
-      "address": "57pDNUSgPdaopT0kbfHDDMvn1UrinoMih2EBlCwPc9OG2lg5GAcSloZSHHFsY",
-      "description": "Generated test vector #802",
-      "expected": [
-        "reflect",
-        "eloquence",
-        "detail",
-        "below",
-        "solve"
-      ]
-    },
-    {
-      "address": "0xC3M2VpPXtUdxRSpKGoOd95tfAPOKrUBCPe9JWnz521uSWu",
-      "description": "Generated test vector #803",
-      "expected": [
-        "rotate",
-        "august",
-        "double",
-        "include",
-        "zebra"
-      ]
-    },
-    {
-      "address": "3hIUk7uNfrnEAym4K2vVIMECfDMj1icShW",
-      "description": "Generated test vector #804",
-      "expected": [
-        "impeccable",
-        "flawless",
-        "educate",
-        "novel",
+        "blush",
+        "opera",
+        "admit",
+        "tunnel",
         "champion"
       ]
     },
     {
-      "address": "1lYPKyttuvpKUcRBNW9aFaq6FDljk13s8Q7ARhsG06vCKj",
-      "description": "Generated test vector #805",
+      "address": "0xhaKH6sU4vzOFjnZmlX0059CIsegSEuhOgM3tB",
+      "description": "Generated test vector #83",
       "expected": [
-        "bench",
-        "spray",
-        "dash",
-        "thing",
-        "trim"
+        "exonerate",
+        "plentiful",
+        "meaningful",
+        "visa",
+        "giraffe"
       ]
     },
     {
-      "address": "osmo1ln4m6u6CPQEn3WiXVGDcPaRKLpDDN",
-      "description": "Generated test vector #806",
+      "address": "cosmos1JwtAapnTB0iT2CwsIkL01iHq2eebFbKz",
+      "description": "Generated test vector #84",
       "expected": [
-        "cake",
-        "deer",
-        "close",
-        "nifty",
-        "work"
-      ]
-    },
-    {
-      "address": "3bWfOJc09yRzVZqj04fh6royFYWTnvm50JS2uBTxmTDIfdEGnKY0qTU7eQfLNL",
-      "description": "Generated test vector #807",
-      "expected": [
-        "member",
-        "keypair",
-        "radio",
-        "tooth",
-        "motor"
-      ]
-    },
-    {
-      "address": "5gJk7Bysn1ctNZy9nbOmi5XdQydF17Y0ds4gmOV3m5TU9",
-      "description": "Generated test vector #808",
-      "expected": [
-        "payment",
-        "token",
-        "safe",
-        "joke",
-        "wins"
-      ]
-    },
-    {
-      "address": "bc1qwj52VKKHBDdwGKVD9Q5xV5uRlYDdhpWZnhFmYAjpU0rwDQT9GkMx",
-      "description": "Generated test vector #809",
-      "expected": [
-        "dwarf",
-        "evocative",
-        "athlete",
-        "february",
-        "great"
-      ]
-    },
-    {
-      "address": "osmo1UDP4uLjQwiHIP13mWjjWSLno6HBLgTmXLzEjGtTqrwcQ3pV5hIv",
-      "description": "Generated test vector #810",
-      "expected": [
-        "reclaim",
-        "black",
-        "favorite",
-        "liking",
-        "flight"
-      ]
-    },
-    {
-      "address": "0xH5Dyt6vbQHOtaa4IQAKXqEenGVHAmxNyu6oYBUzo7J1j1Q5kh5vlEm2ErtukL",
-      "description": "Generated test vector #811",
-      "expected": [
-        "anchor",
-        "leader",
-        "school",
-        "circle",
-        "shuffle"
-      ]
-    },
-    {
-      "address": "0x4aDUbD4IkewKB8zaHTthIBs8oBmBGvBsUQvOwhhNH7qXLy4p",
-      "description": "Generated test vector #812",
-      "expected": [
-        "pencil",
-        "book",
-        "giraffe",
-        "sober",
-        "metal"
-      ]
-    },
-    {
-      "address": "osmo1vpDrBjiFFBxYW4fHIGuE1H8hlKNbdKtvhotw",
-      "description": "Generated test vector #813",
-      "expected": [
-        "bike",
-        "gallery",
-        "amused",
-        "click",
-        "mint"
-      ]
-    },
-    {
-      "address": "0xTenslz1TD8lo64WVum2mSLD5YPbyYFThzaEENNF1jRDl0Ac5",
-      "description": "Generated test vector #814",
-      "expected": [
-        "aspiration",
-        "ally",
-        "panther",
-        "know",
-        "sustain"
-      ]
-    },
-    {
-      "address": "qzkKYS10zJO9Fuua2dNrwcRLjL89Vbf5LSQjwBjrouse",
-      "description": "Generated test vector #815",
-      "expected": [
-        "profit",
-        "cable",
-        "filter",
-        "volume",
-        "glamorous"
-      ]
-    },
-    {
-      "address": "osmo1EeBmIVSWkXtf2W0CcFFautmIamyMDBnMwVT8vX0zzlWHtHIWZl1G",
-      "description": "Generated test vector #816",
-      "expected": [
-        "install",
-        "alcohol",
-        "pottery",
-        "list",
-        "thought"
-      ]
-    },
-    {
-      "address": "osmo1B2Ijr7Jtngo1Alc7xnzq5m1WV5AkHAPcyD9vwWT",
-      "description": "Generated test vector #817",
-      "expected": [
-        "ardor",
-        "during",
-        "sincere",
-        "aid",
-        "exquisite"
-      ]
-    },
-    {
-      "address": "osmo1ga6UPB3i8slQXHMFeM4XGjvFUWNcbrhXfdC6VJhxGhV",
-      "description": "Generated test vector #818",
-      "expected": [
-        "fiscal",
-        "exalt",
-        "essay",
-        "cloud",
-        "walk"
-      ]
-    },
-    {
-      "address": "1vwxBorRBOccZus6IiMb2JQ5xLtpBvR3Z65",
-      "description": "Generated test vector #819",
-      "expected": [
-        "excess",
-        "roof",
-        "alone",
-        "arrest",
-        "wise"
-      ]
-    },
-    {
-      "address": "bc1qnnsikwV4gcToeVsNlqNWNSypLVTqn4SbR2S1HTEktsQxTdJ6nEa",
-      "description": "Generated test vector #820",
-      "expected": [
-        "outside",
-        "analyst",
-        "brisk",
         "soul",
-        "dwarf"
+        "swank",
+        "excite",
+        "scissors",
+        "another"
       ]
     },
     {
-      "address": "3874g3oMsLQIwgpqz9wojvAhyFyVkU2vEUKtr",
-      "description": "Generated test vector #821",
+      "address": "bc1qIH9DWwnVTsCFyFP0YMkFBl6O7TDw",
+      "description": "Generated test vector #85",
       "expected": [
-        "crawl",
-        "visual",
-        "discover",
-        "artist",
-        "laugh"
-      ]
-    },
-    {
-      "address": "0xNOMBConVVfA3k6Zq4pfzcqVwArvOTi3",
-      "description": "Generated test vector #822",
-      "expected": [
-        "style",
-        "safe",
-        "lesson",
-        "list",
-        "silk"
-      ]
-    },
-    {
-      "address": "5TwfPJ2Z5YIpFZiLYYBK5TtkDzREOhB03akRlljvxIi6SZmp",
-      "description": "Generated test vector #823",
-      "expected": [
-        "actor",
-        "celebrate",
-        "impulse",
-        "enroll",
-        "civil"
-      ]
-    },
-    {
-      "address": "1v0Jv51MV1vw3Fd4OGkajeymcPOnGgWjDBp2hBSBAM4X1J0VHBRUK",
-      "description": "Generated test vector #824",
-      "expected": [
-        "dash",
-        "immortal",
-        "staff",
-        "sturdier",
-        "kiss"
-      ]
-    },
-    {
-      "address": "3qLWmENE9ZUzFRL24uzABFVbehSW2DLvs4IHlgt86TFgyHap",
-      "description": "Generated test vector #825",
-      "expected": [
-        "nice",
-        "verify",
-        "dish",
-        "option",
-        "grab"
-      ]
-    },
-    {
-      "address": "3dhLFZTM27evWPoE4wpY1JfPWaAlSvrci4OYt7ILi5uNIR137gXpczeGcuDMK5bi",
-      "description": "Generated test vector #826",
-      "expected": [
-        "grace",
-        "myself",
-        "general",
-        "voyage",
-        "enlightened"
-      ]
-    },
-    {
-      "address": "c9Dv1Ay5dHzfy5PksBo9dQC5UJma3j4vXP",
-      "description": "Generated test vector #827",
-      "expected": [
-        "write",
-        "fancy",
-        "jellyfish",
-        "again",
-        "budget"
-      ]
-    },
-    {
-      "address": "3XDN96EFuOMS0MdkohukKZkJPkVpgK0pQ0sVwofHWwqHdYZJTqAy9Zp",
-      "description": "Generated test vector #828",
-      "expected": [
-        "inhale",
-        "style",
-        "sort",
-        "sober",
-        "atom"
-      ]
-    },
-    {
-      "address": "osmo18OOr4HHwaTU8MdlBiNeowKFrmgUPKqhfzfMm5ml0A9YxQm9U",
-      "description": "Generated test vector #829",
-      "expected": [
-        "heart",
-        "raw",
-        "quantum",
-        "layer",
-        "close"
-      ]
-    },
-    {
-      "address": "3y6oxs47laDQhXsCTcVLNwILSaZYzBYNjzoLfXolgObRX8Wx9dzUbs",
-      "description": "Generated test vector #830",
-      "expected": [
-        "feature",
-        "usual",
-        "pet",
-        "overjoyed",
-        "empty"
-      ]
-    },
-    {
-      "address": "3wBBfscDElhEQ50EXVk9tC4M45KSyT1g8t7fpShsXt",
-      "description": "Generated test vector #831",
-      "expected": [
-        "where",
-        "catch",
-        "absent",
-        "metal",
-        "claim"
-      ]
-    },
-    {
-      "address": "osmo17BePmeT32qJ5Qyt4tdvTap3OX5z4Cxm2hPCG1PGZfk67",
-      "description": "Generated test vector #832",
-      "expected": [
-        "hot",
-        "magic",
-        "image",
-        "deft",
-        "valve"
-      ]
-    },
-    {
-      "address": "qzkwZqbJP054siyd3BYjsh1mVk7R0Zp9tsyBrUjo0N32hee5qdG6Lv",
-      "description": "Generated test vector #833",
-      "expected": [
-        "move",
-        "farm",
-        "sparkle",
-        "ribbon",
-        "plate"
-      ]
-    },
-    {
-      "address": "osmo1o4AteUrpl5gA1JtAWOrf2D9O5NsA2pgQ6H",
-      "description": "Generated test vector #834",
-      "expected": [
-        "century",
-        "desert",
-        "luster",
-        "likable",
-        "now"
-      ]
-    },
-    {
-      "address": "0xHJQtUdIVoagPN7NEZoqn9Z1DALcPFwZwoP0D1d8Xnb4huyJBNTwJuW6cv5",
-      "description": "Generated test vector #835",
-      "expected": [
-        "nourish",
-        "people",
-        "blameless",
-        "fire",
-        "lawsuit"
-      ]
-    },
-    {
-      "address": "3eqTyFym2L3rANfvqYS5N5xTF3LFHTOyXfh7YCKL2jZjofuEiaQZGvUAAQR7ql",
-      "description": "Generated test vector #836",
-      "expected": [
-        "rollup",
-        "degree",
-        "elf",
-        "nourish",
-        "decide"
-      ]
-    },
-    {
-      "address": "3OEitER1lWPtjLlBoDgOCMMid1uJP0u74YaVwQTHEXRnsWECvjGMAQ4hjogON",
-      "description": "Generated test vector #837",
-      "expected": [
-        "diesel",
-        "ambitious",
-        "desert",
-        "stomach",
-        "basket"
-      ]
-    },
-    {
-      "address": "bc1qdbuxVc1zJ7ZYS2kiTl14IWGtRXdVVJmZgD98IBG",
-      "description": "Generated test vector #838",
-      "expected": [
-        "rhythm",
-        "celebrate",
-        "ratified",
-        "mixture",
-        "juice"
-      ]
-    },
-    {
-      "address": "qzkh6gYTlxda9KBxMeBHqLIVpaBrO3XHfXBPJysw",
-      "description": "Generated test vector #839",
-      "expected": [
-        "fiscal",
-        "choose",
-        "draw",
-        "adequate",
-        "squirrel"
-      ]
-    },
-    {
-      "address": "cosmos1BE8a44t6G04IghFPYJUGtXi4",
-      "description": "Generated test vector #840",
-      "expected": [
-        "pretty",
-        "cloud",
-        "lemur",
-        "arrange",
-        "arctic"
-      ]
-    },
-    {
-      "address": "cosmos1D8V7FTnexVg2YoUBbzQENPyVogWeAfg7uUbpmhlQoEeCVnJObgHida",
-      "description": "Generated test vector #841",
-      "expected": [
-        "oak",
-        "yellow",
-        "work",
-        "ardor",
-        "siren"
-      ]
-    },
-    {
-      "address": "osmo1iDXyZBQhAqDj25dAuiObSnY6MhbBj3TMDY8boRRa8gLX7z16UrA6B9RHeT",
-      "description": "Generated test vector #842",
-      "expected": [
-        "elevator",
-        "shrimp",
-        "bloom",
-        "pumpkin",
-        "author"
-      ]
-    },
-    {
-      "address": "cosmos19ctd7wf3wQuE9aWdTOXLKp5bnpMscTHyDJ0WqAtp8",
-      "description": "Generated test vector #843",
-      "expected": [
-        "cement",
-        "chuckle",
-        "job",
-        "pilot",
-        "room"
-      ]
-    },
-    {
-      "address": "0x3csz0pCGnTHBkzr3KirAtAflcDue9g",
-      "description": "Generated test vector #844",
-      "expected": [
-        "butter",
-        "mightily",
-        "carbon",
-        "announce",
-        "income"
-      ]
-    },
-    {
-      "address": "1vQxIhJLtg6BZ0WpNQDX18P2YZgc7oZRhCDktxzpsxAw6F3lQfPoFV",
-      "description": "Generated test vector #845",
-      "expected": [
-        "actual",
-        "attend",
-        "analyst",
-        "match",
-        "response"
-      ]
-    },
-    {
-      "address": "11NqUQV5KSWCS8f14sG59baOx01pz2XjUI0FINDpyNXzp",
-      "description": "Generated test vector #846",
-      "expected": [
-        "add",
-        "effective",
-        "father",
-        "valve",
-        "post"
-      ]
-    },
-    {
-      "address": "qzkCcp1vI1CA0JtACA6UQfhlwxpvOLhAJ00GwUBJbxO",
-      "description": "Generated test vector #847",
-      "expected": [
-        "across",
-        "ameliorate",
-        "sibling",
+        "inside",
+        "video",
+        "buyer",
         "deposit",
-        "ledger"
+        "verify"
       ]
     },
     {
-      "address": "bc1qEP1WDDZgcX0D5iw7bfwrMcZMMHCuw9nq45IwTROyZUzpuqlR8bJv",
-      "description": "Generated test vector #848",
+      "address": "bc1qoqoPGXy42cOg8NqTJJxxK3ep8nzYvX3a2BoFrjjLYOzuhPDKOzphKiF3j",
+      "description": "Generated test vector #86",
       "expected": [
-        "burger",
-        "oyster",
-        "stellar",
-        "group",
-        "meadow"
-      ]
-    },
-    {
-      "address": "bc1qQj5DGRWDJP2E6I901TNAyo5YHW",
-      "description": "Generated test vector #849",
-      "expected": [
-        "that",
-        "glass",
-        "area",
-        "opera",
-        "domain"
-      ]
-    },
-    {
-      "address": "3A2qk4LZ9mwdDZXAnEWQprg9IeglQKbZDkLvgLvMGDFmDcGmUUZJi6DoZA1",
-      "description": "Generated test vector #850",
-      "expected": [
-        "tidy",
-        "elder",
-        "tube",
-        "major",
-        "panel"
-      ]
-    },
-    {
-      "address": "3MgaRPN4MhRJs3cegjCLfAwv8ObloYUdw78QOpn6rlPSw1U",
-      "description": "Generated test vector #851",
-      "expected": [
-        "include",
-        "prowess",
-        "eternal",
-        "quality",
-        "question"
-      ]
-    },
-    {
-      "address": "cosmos1GspSoMNuTa8lBXQeCmejc0vjBLr0NPRpC",
-      "description": "Generated test vector #852",
-      "expected": [
-        "stay",
-        "finish",
-        "talent",
-        "furnace",
+        "decorate",
+        "escape",
+        "muffin",
+        "head",
         "knife"
       ]
     },
     {
-      "address": "5VE2T2GZ1ekGBkEpWxMdbx2WL17xlUgtnPdbbe3CgeKXpQC9lwGgMnwbKw3",
-      "description": "Generated test vector #853",
+      "address": "35Gz8N2TY6nLDDnziKVMFkQ5KexibG4QZLl3L2GUfO3Ha6",
+      "description": "Generated test vector #87",
       "expected": [
-        "wolf",
-        "grocery",
-        "head",
-        "order",
-        "below"
+        "light",
+        "style",
+        "pencil",
+        "sober",
+        "prepare"
       ]
     },
     {
-      "address": "12SFwBn2YDRSS9Qrl4BzbEolg590BCo",
-      "description": "Generated test vector #854",
+      "address": "5A2RA6DVvX4ZJApV4fLHpaUaGGxmXzgAKqHJL9ymIIlID9JWyi1hoW6gFWXMQdy",
+      "description": "Generated test vector #88",
       "expected": [
-        "wheel",
-        "onion",
-        "open",
-        "peanut",
-        "borrow"
+        "burst",
+        "record",
+        "stock",
+        "hill",
+        "stone"
       ]
     },
     {
-      "address": "qzkf2aO6JzeXI04jT3aaeGu0K5d4tf6p",
-      "description": "Generated test vector #855",
+      "address": "0xZDLfqwLS5yOr7dVkEa05GmWFRMPwO8fry",
+      "description": "Generated test vector #89",
       "expected": [
-        "dash",
-        "useful",
-        "reason",
-        "confirm",
-        "wheel"
-      ]
-    },
-    {
-      "address": "ZZfZSbW7vftpeg6L47YzZjzWXRq5U9Lz",
-      "description": "Generated test vector #856",
-      "expected": [
-        "slush",
-        "ostrich",
-        "noble",
-        "thrive",
-        "there"
-      ]
-    },
-    {
-      "address": "osmo140ujDaqlyqdKqUFUWVupgGEEXsIWxwI6JP1vEIyTx",
-      "description": "Generated test vector #857",
-      "expected": [
-        "dry",
-        "initial",
-        "dwarf",
-        "have",
-        "valley"
-      ]
-    },
-    {
-      "address": "osmo1qTfs8UM5VUENGdvcuhBFzVkF26B",
-      "description": "Generated test vector #858",
-      "expected": [
-        "monkey",
-        "muscle",
-        "economy",
-        "chapter",
-        "hottest"
-      ]
-    },
-    {
-      "address": "cosmos1pzIFs25BxHBaAeqAJj5KOCzgcp1WtbEa",
-      "description": "Generated test vector #859",
-      "expected": [
-        "prolific",
-        "detail",
-        "oven",
-        "all",
-        "alone"
-      ]
-    },
-    {
-      "address": "qzkUgU2aBDpF8wBGADXAEQLjZIoKhm6KjwCkwEnAZ4rQ3QgQcKYY",
-      "description": "Generated test vector #860",
-      "expected": [
-        "swarm",
-        "myself",
-        "exuberance",
-        "boy",
-        "triumph"
-      ]
-    },
-    {
-      "address": "qzkK09HfPkUXdnfaIcwZcezOSTyod35M2Mty3UBz8zXv15Ux9iw8xE5",
-      "description": "Generated test vector #861",
-      "expected": [
-        "volume",
-        "silent",
-        "dad",
-        "crawl",
-        "empathize"
-      ]
-    },
-    {
-      "address": "0xl2wX94yqLI5YY41Eg04NrhddayHF97oSYI7Ur",
-      "description": "Generated test vector #862",
-      "expected": [
-        "jellyfish",
-        "permissible",
-        "current",
-        "melt",
-        "identify"
-      ]
-    },
-    {
-      "address": "0xRtOzRL0M3xJ0pxXrCLdZtIpqaEGb0Aw9a6c5X3hM5u",
-      "description": "Generated test vector #863",
-      "expected": [
-        "diagram",
-        "hooray",
-        "potato",
-        "museum",
-        "sophisticated"
-      ]
-    },
-    {
-      "address": "qzksnHWHltxFFWBvnaQ7wtwdljDfBFP8vSh8MQ2NfbUYgbSZENc",
-      "description": "Generated test vector #864",
-      "expected": [
-        "proof",
-        "silk",
-        "lens",
-        "crowd",
-        "play"
-      ]
-    },
-    {
-      "address": "cosmos1eALZnVDRjWI3KBFZmJjw0LxdzzcfsYhDLsfOHYJ3yrls8v",
-      "description": "Generated test vector #865",
-      "expected": [
-        "render",
-        "woman",
-        "captain",
-        "fantasy",
-        "book"
-      ]
-    },
-    {
-      "address": "bc1qO38QKXxAVwUK94xoO8HMJ2WoPcmrYnY",
-      "description": "Generated test vector #866",
-      "expected": [
-        "soothe",
-        "memory",
-        "trivial",
-        "winner",
-        "pupil"
-      ]
-    },
-    {
-      "address": "NoPxVuLSjbaWpZ45AscEjcjtTL7mFw8EG0W8jl0IbL9HsENCgQygIO2O30zG9kO",
-      "description": "Generated test vector #867",
-      "expected": [
-        "wine",
-        "ally",
-        "panel",
-        "advance",
-        "incredible"
-      ]
-    },
-    {
-      "address": "1HJax2yXQG2jKt1wHqt5AWQLjrPLCLahIGqSM4vSpGCJ6Xq6pp3txQ4Nx",
-      "description": "Generated test vector #868",
-      "expected": [
-        "real",
-        "corn",
-        "fidelity",
-        "bold",
-        "care"
-      ]
-    },
-    {
-      "address": "3nPFbRUzd5LJNsNGSaRBk8WR0BhT2Gb9eWtH",
-      "description": "Generated test vector #869",
-      "expected": [
-        "panther",
-        "thrill",
-        "wolf",
-        "party",
-        "grocery"
-      ]
-    },
-    {
-      "address": "1NBSrk80PyiDL7pmg8joYv1DAbta4GSy3VuBzxhMEP0vh",
-      "description": "Generated test vector #870",
-      "expected": [
-        "fog",
-        "stomach",
-        "body",
-        "elbow",
-        "action"
-      ]
-    },
-    {
-      "address": "osmo1juWyklL9k8AMcPg9qokS5IPG9MXZPLyjOpOTlzAfoyEN",
-      "description": "Generated test vector #871",
-      "expected": [
-        "dove",
-        "this",
-        "holy",
-        "sample",
-        "seamless"
-      ]
-    },
-    {
-      "address": "0xmOesVjjowObTjA11NcXeLc4fcgyZKuvtScf210iTEsVQXaO",
-      "description": "Generated test vector #872",
-      "expected": [
-        "runway",
-        "eternal",
-        "claim",
-        "dinosaur",
-        "couple"
-      ]
-    },
-    {
-      "address": "3vPJ5C5mE7jzyY3JgUdGPUehEn4ajcbqjCAWpZ",
-      "description": "Generated test vector #873",
-      "expected": [
-        "lounge",
-        "salute",
-        "board",
-        "frog",
-        "rise"
-      ]
-    },
-    {
-      "address": "cosmos1u4P4dtlEE0e9aFR2lZ3ISvL3Et5lqevu77T0koXg5qo4p7i7C",
-      "description": "Generated test vector #874",
-      "expected": [
-        "brass",
-        "abstract",
-        "bring",
-        "web",
-        "fluid"
-      ]
-    },
-    {
-      "address": "cosmos1NroSjRvCA4ENrRs1DCqNyqMj1TFPsIaB3OebJIskF",
-      "description": "Generated test vector #875",
-      "expected": [
-        "person",
-        "before",
-        "stuff",
-        "job",
-        "assume"
-      ]
-    },
-    {
-      "address": "bc1qxqhFAF7DW71lFevwIJw0Gqq93vhjVr",
-      "description": "Generated test vector #876",
-      "expected": [
-        "ripple",
-        "verify",
-        "blockbuster",
-        "chill",
-        "adequate"
-      ]
-    },
-    {
-      "address": "cosmos1d1QFb0n6ouOo5HW41MUmQZjkNXltj8FtqEIKVNCE",
-      "description": "Generated test vector #877",
-      "expected": [
-        "head",
-        "visa",
-        "zeal",
-        "lucky",
-        "stairs"
-      ]
-    },
-    {
-      "address": "osmo1BM6SN5xnBlpOV9iuj7EGpEDMX0",
-      "description": "Generated test vector #878",
-      "expected": [
-        "kitten",
-        "become",
-        "flip",
-        "blossom",
-        "splendid"
-      ]
-    },
-    {
-      "address": "bc1qLGEuROMMZmJgGwq1YHnFw83jkYUbA4gLJk5BXZ97wun7eOJVePNYux",
-      "description": "Generated test vector #879",
-      "expected": [
-        "flock",
-        "way",
-        "shield",
-        "exuberance",
-        "salad"
-      ]
-    },
-    {
-      "address": "1U1xNiXXWkGtLI3YPU2dahhuFO2WlMa33ZxLkIN4QR5EPXWl4PDme2kqX",
-      "description": "Generated test vector #880",
-      "expected": [
-        "client",
-        "ahead",
-        "bamboo",
-        "social",
-        "exonerate"
-      ]
-    },
-    {
-      "address": "iOBBlg1sOqWhRxq8J8VxNPIaJ5ZVBP0B5PzuOdP3jf4W6fGC9DJqZxA4MXTQX",
-      "description": "Generated test vector #881",
-      "expected": [
-        "whisper",
-        "vivid",
-        "mirror",
-        "squeeze",
-        "wire"
-      ]
-    },
-    {
-      "address": "1dqqaf9yxCRCzNV5wCliNDsVuAubUTodW3ARhRN1ZZ6u03nZam2",
-      "description": "Generated test vector #882",
-      "expected": [
-        "note",
-        "tranquil",
-        "donate",
-        "permissible",
-        "dentist"
-      ]
-    },
-    {
-      "address": "cosmos1HaEGNZjm5Xxvdg0AhLn0CudhC0NQBAmK8",
-      "description": "Generated test vector #883",
-      "expected": [
-        "gate",
-        "friend",
-        "catch",
-        "stable",
-        "above"
-      ]
-    },
-    {
-      "address": "5c5ydCMZ1j1FbPEGSCIFFpnvzGyQ9BpF6o26JB3pYKwh90XnCjOeuBT7rH",
-      "description": "Generated test vector #884",
-      "expected": [
-        "embrace",
-        "sustain",
-        "play",
-        "fence",
-        "citizen"
-      ]
-    },
-    {
-      "address": "6Uz6NZYhoeXdrNPWOxJNDHXhOLwFeoYXb3KsTrqVQ",
-      "description": "Generated test vector #885",
-      "expected": [
-        "rescue",
-        "puzzle",
-        "trend",
-        "befit",
-        "fog"
-      ]
-    },
-    {
-      "address": "uLnpjI29R8MQA0KbF97dA5e7s1AN2ygVQZ",
-      "description": "Generated test vector #886",
-      "expected": [
-        "believe",
-        "ambitious",
-        "wide",
-        "any",
-        "elf"
-      ]
-    },
-    {
-      "address": "cosmos18z1d8vG8IrQpOEQ8tEraomwUGzBKLljts",
-      "description": "Generated test vector #887",
-      "expected": [
-        "bounty",
-        "privilege",
-        "cure",
-        "treat",
-        "edit"
-      ]
-    },
-    {
-      "address": "qzkq7LK015lwLca1YoqMii4EVdusQAkMUTqRpWfGahOvzrg71gMVww8j",
-      "description": "Generated test vector #888",
-      "expected": [
-        "moment",
-        "solid",
-        "walk",
-        "affection",
-        "confirm"
-      ]
-    },
-    {
-      "address": "bc1qwFnEhtktQSjoRfmvUX2uBIE2xaR1uuG9sGMsDQjxwvBllTCV2jN17SxG",
-      "description": "Generated test vector #889",
-      "expected": [
-        "comfort",
-        "advocate",
-        "praise",
-        "defense",
-        "blur"
-      ]
-    },
-    {
-      "address": "osmo1HZiimRfzC0dw0NBbWZVZ26B5U0HRATf99KDG1Q0pl5I9XRO",
-      "description": "Generated test vector #890",
-      "expected": [
-        "pony",
-        "fair",
-        "possible",
-        "true",
-        "vacuum"
-      ]
-    },
-    {
-      "address": "bc1qXuQwmNXyXujux6jH2mrzpq8KQxndeQ6cTJXmLvcx0mSMejK9xs",
-      "description": "Generated test vector #891",
-      "expected": [
-        "ask",
-        "ability",
-        "topnotch",
-        "toe",
-        "twenty"
-      ]
-    },
-    {
-      "address": "3FRXgdAlaxu7U4tcKMenkGMPZP63VGxbe2agKk7RbWzbO8PrWqXEW0k1SEEz1",
-      "description": "Generated test vector #892",
-      "expected": [
-        "fiscal",
-        "actor",
-        "connect",
-        "birth",
-        "pond"
-      ]
-    },
-    {
-      "address": "bc1qSe5dsFsoV8JE7xSqhhVcY0DCLSQoh7",
-      "description": "Generated test vector #893",
-      "expected": [
-        "infant",
-        "vehicle",
-        "avocado",
-        "assist",
-        "material"
-      ]
-    },
-    {
-      "address": "osmo1tadQgeGBUtR1EtHfetYbn1hv1kyIJavgc8ZCOlun1kmOeP7k0OI0Z",
-      "description": "Generated test vector #894",
-      "expected": [
-        "theme",
-        "salon",
-        "curious",
-        "floor",
-        "unparalleled"
-      ]
-    },
-    {
-      "address": "cosmos1e4rMfRYcCiEcUwRJIA0mQ2o",
-      "description": "Generated test vector #895",
-      "expected": [
-        "when",
-        "purity",
-        "energy",
-        "globe",
-        "myself"
-      ]
-    },
-    {
-      "address": "bc1qb7SAuetZq6Ec3PY6gnhKBd1K6XsatNmJQzoInxOG7DmLK2baX",
-      "description": "Generated test vector #896",
-      "expected": [
-        "index",
-        "tomorrow",
-        "twist",
-        "cloud",
-        "brick"
-      ]
-    },
-    {
-      "address": "cosmos1yQEcSAohyaZbJV4w0FPSs1rkggOLi",
-      "description": "Generated test vector #897",
-      "expected": [
-        "order",
-        "banner",
-        "august",
-        "smitten",
-        "pardon"
-      ]
-    },
-    {
-      "address": "3f8gG5aU0gEvCv4U5y4Dvby2OPP4Mr",
-      "description": "Generated test vector #898",
-      "expected": [
-        "ultra",
-        "history",
-        "panel",
-        "kidney",
-        "able"
-      ]
-    },
-    {
-      "address": "bc1qvHUNZNWkia068eboWvrxspWSSUh466udsJw77dM38SvD8A4iBipzf",
-      "description": "Generated test vector #899",
-      "expected": [
-        "blockbuster",
-        "between",
-        "landmark",
-        "fiery",
-        "ameliorate"
-      ]
-    },
-    {
-      "address": "0x6qdGqAscZzBgdAkwu4mOlUBllbJsewQfp8MvIIIBMn0UM4b4V7kKO8AgYW6rr",
-      "description": "Generated test vector #900",
-      "expected": [
-        "field",
-        "avid",
-        "jewel",
-        "ceiling",
-        "page"
-      ]
-    },
-    {
-      "address": "5xCYxucqvUe12sXZJJw22JkAaGMVgoPjQip6PSVuIH71I0cvGmL9c1m8E3TH",
-      "description": "Generated test vector #901",
-      "expected": [
-        "remunerate",
-        "onion",
-        "bounty",
-        "triumph",
-        "gripping"
-      ]
-    },
-    {
-      "address": "0xIGbTNCyiQe1hbaEgCL8s4t6r0K9htFXDIshQNUxELL",
-      "description": "Generated test vector #902",
-      "expected": [
-        "trumpet",
-        "sunny",
-        "mystery",
-        "mesmerize",
-        "marriage"
-      ]
-    },
-    {
-      "address": "qzkIlzkDkqoUl1MJ9uztXg6dol3yOo6WBYHNUcvS",
-      "description": "Generated test vector #903",
-      "expected": [
-        "absorb",
-        "majestic",
-        "april",
-        "drink",
-        "stable"
-      ]
-    },
-    {
-      "address": "1DaQloUBTnpcne9levPSXUihg9C5kBpH2UTt",
-      "description": "Generated test vector #904",
-      "expected": [
-        "ozone",
-        "alien",
-        "mirror",
-        "length",
-        "mesmerize"
-      ]
-    },
-    {
-      "address": "cosmos15Xzs39dgyHKzoNbHO3qIcsPDT3z3aGcQ63FMUPr6XlG",
-      "description": "Generated test vector #905",
-      "expected": [
-        "student",
-        "lemur",
-        "early",
-        "lifesaver",
-        "classy"
-      ]
-    },
-    {
-      "address": "3emQc6HnYZeIQGl4VKmUavOa3GTrgfrzJSmQzYmoTO3kERIIw3OlQHckm",
-      "description": "Generated test vector #906",
-      "expected": [
-        "hardy",
-        "nose",
-        "affinity",
-        "monitor",
-        "premier"
-      ]
-    },
-    {
-      "address": "qzkzOpt4DGzjELaj4QGeubKzHkFpLnOuNn",
-      "description": "Generated test vector #907",
-      "expected": [
-        "school",
-        "gaze",
-        "tuna",
-        "umbrella",
-        "month"
-      ]
-    },
-    {
-      "address": "0x7XWOGqJptZAGj6WcksFgQvXPWUodREbQrE9r8",
-      "description": "Generated test vector #908",
-      "expected": [
-        "post",
-        "casual",
-        "oxygen",
-        "bean",
-        "base"
-      ]
-    },
-    {
-      "address": "3pB92j9mArBFynBOIRDnXXCzR8l2QN",
-      "description": "Generated test vector #909",
-      "expected": [
-        "upscale",
-        "dynamic",
-        "lava",
-        "gallery",
-        "remember"
-      ]
-    },
-    {
-      "address": "bc1qI1dwDezIN7z5ppTZzf1qnDDEGIQrvoe85FRBt24lM9ciqav0EdhD",
-      "description": "Generated test vector #910",
-      "expected": [
-        "state",
-        "creek",
-        "venue",
-        "good",
-        "dinosaur"
-      ]
-    },
-    {
-      "address": "MWKHeygaoSmksnX9TbnpMB3IaTt1az0MK4aESFMme",
-      "description": "Generated test vector #911",
-      "expected": [
-        "oven",
-        "recipe",
-        "amenity",
-        "tribe",
-        "undeniable"
-      ]
-    },
-    {
-      "address": "3cPXKl3e6xwtsxNI8QPPUWy2utnSVZhJabAxh2X1OmexbQsRx",
-      "description": "Generated test vector #912",
-      "expected": [
-        "slick",
-        "deft",
-        "above",
-        "peace",
-        "earn"
-      ]
-    },
-    {
-      "address": "qzkFsoQ2xMBC0wybIq9zxoGjNLKAyTHW6Yh",
-      "description": "Generated test vector #913",
-      "expected": [
-        "cherry",
-        "wins",
-        "coach",
-        "purse",
-        "vigor"
-      ]
-    },
-    {
-      "address": "qzkGcgNl86GqgXy421L1jUL2LQs6ekXr0uZLK5Dvy0UE6dN6v1",
-      "description": "Generated test vector #914",
-      "expected": [
-        "cause",
-        "stroll",
-        "train",
-        "twice",
-        "empower"
-      ]
-    },
-    {
-      "address": "bc1qROw7dgyC79LXONUSi1xneAtWKhiZsqbkR2rsITi0BJ7oyEVG0LKLaV",
-      "description": "Generated test vector #915",
-      "expected": [
-        "later",
-        "spice",
-        "joyful",
-        "trend",
-        "nautilus"
-      ]
-    },
-    {
-      "address": "o49sHoKU3rdrsCldisvjIdLpZkD4C82phpXoH86btGLQPbOxEC3DblOMZ",
-      "description": "Generated test vector #916",
-      "expected": [
-        "elan",
-        "soup",
-        "organ",
-        "smile",
-        "hidden"
-      ]
-    },
-    {
-      "address": "3y6Z59DVVYYf8WezzTT0zzooImHo6iXiQMAbpyYrEbtyq7ppIu",
-      "description": "Generated test vector #917",
-      "expected": [
-        "snazzy",
-        "they",
-        "knife",
-        "feel",
-        "stem"
-      ]
-    },
-    {
-      "address": "1gCk4O0R1M34kabPkbpxbNyAzc5L2lWtXaq75N",
-      "description": "Generated test vector #918",
-      "expected": [
-        "observe",
-        "snack",
-        "simple",
-        "beckon",
-        "element"
-      ]
-    },
-    {
-      "address": "osmo1QRjAz0OkB47J0XoZB0tjfqXB7f1S6204VdzenHdO2EplzZnNAR3rUhOdV",
-      "description": "Generated test vector #919",
-      "expected": [
-        "volume",
-        "luminous",
-        "ready",
-        "caution",
-        "fuel"
-      ]
-    },
-    {
-      "address": "TzPBsd26UMRFL3QZ8vYqlN7AZH1XOE9fVW9rSX0pVWCqf1t",
-      "description": "Generated test vector #920",
-      "expected": [
-        "churn",
-        "ability",
-        "decade",
-        "derive",
-        "august"
-      ]
-    },
-    {
-      "address": "osmo12iqVPtqSedMPNgMWvKnBuXotqt7Kp3VHQpbKk4Ugw57Ip2vlbcVNVmlM2i3",
-      "description": "Generated test vector #921",
-      "expected": [
-        "cash",
-        "never",
-        "area",
-        "raven",
-        "panel"
-      ]
-    },
-    {
-      "address": "osmo1R6SxjFLxXTBQZYKLVmbQeHFVHGl26a0vl1FLGa0IIYNKVGzX",
-      "description": "Generated test vector #922",
-      "expected": [
-        "deputy",
-        "tip",
-        "excite",
-        "gutsy",
-        "ginger"
-      ]
-    },
-    {
-      "address": "0xUvAPQxD34B6YFwCuXIbiE2PhpXKcCrKNZ5p9lkjNp3qQogD4OUaedmy4",
-      "description": "Generated test vector #923",
-      "expected": [
-        "soccer",
-        "upheld",
-        "spoil",
-        "there",
-        "year"
-      ]
-    },
-    {
-      "address": "1MN53fN8zAD9EJvBAiRbp73VlOexNGlu95d7sYxxRncxXj1oyii9xT9",
-      "description": "Generated test vector #924",
-      "expected": [
-        "fire",
-        "legend",
-        "panel",
-        "flower",
-        "wife"
-      ]
-    },
-    {
-      "address": "qzkccyA7o4G2kpHcCXbODYZSTOCTVqNQTHwUB",
-      "description": "Generated test vector #925",
-      "expected": [
-        "marine",
-        "bracket",
-        "process",
-        "octopus",
-        "utility"
-      ]
-    },
-    {
-      "address": "0xXnM1tKTrELf8YVSKMU6GH0tncatnqnqYkW0aj7DuBm",
-      "description": "Generated test vector #926",
-      "expected": [
-        "donate",
-        "head",
-        "hood",
-        "suave",
-        "rectified"
-      ]
-    },
-    {
-      "address": "5WfAGvg0i9mlYFfXkynpbVd64I8Y9a3FARgVFsRoytZCDfig",
-      "description": "Generated test vector #927",
-      "expected": [
-        "salad",
-        "review",
-        "story",
-        "save",
-        "tackle"
-      ]
-    },
-    {
-      "address": "5gJ37029384hu5EZBeCayzNq9ZgDo20AJlC8vtBxKJRSYnZxy3cS8OOTbqS2vOd",
-      "description": "Generated test vector #928",
-      "expected": [
-        "rhythm",
-        "jump",
-        "spoil",
-        "unveil",
-        "october"
-      ]
-    },
-    {
-      "address": "qzkv9gLxPTidt4jSzRw7LRQMoXFsy59YQ4",
-      "description": "Generated test vector #929",
-      "expected": [
-        "flock",
-        "ten",
-        "still",
-        "godsend",
-        "narrow"
-      ]
-    },
-    {
-      "address": "0xlTFtRzdZ4b5HvfGqmYmpAd9GBMU5ri3qRCiXErbzEiNiGTGbSNKuAkR",
-      "description": "Generated test vector #930",
-      "expected": [
-        "fast",
-        "evidence",
-        "dove",
-        "month",
-        "add"
-      ]
-    },
-    {
-      "address": "0xvGjiDmg5ufP6IC8naXM8Uq9AS0iyLFuVzlDegxOMsqCSZab",
-      "description": "Generated test vector #931",
-      "expected": [
-        "genius",
-        "champion",
-        "polished",
         "tunnel",
-        "action"
+        "spell",
+        "daughter",
+        "midnight",
+        "hold"
       ]
     },
     {
-      "address": "qzkQR7EAHGhHplBEVmLHN2hphZXHh2P2YtERvzYgNJgOsW",
-      "description": "Generated test vector #932",
+      "address": "5KGTefrZ4v7rLm5Jqzges6X72YJR7IVU7CCKbheN9Pot7GaZpfPYe5D",
+      "description": "Generated test vector #90",
       "expected": [
-        "update",
-        "bargain",
-        "ultra",
-        "sustain",
-        "tennis"
-      ]
-    },
-    {
-      "address": "bc1qNZFO6tpI3agCe28R4xFuZLZfBqJ6aGO",
-      "description": "Generated test vector #933",
-      "expected": [
-        "involve",
-        "agent",
-        "define",
-        "assume",
-        "toast"
-      ]
-    },
-    {
-      "address": "0xKjJcyZLVuUcRpAtYNI7G5o2tlz9IwHPhGIaRaumHHyGDjS0j49ae9H3AT6mRC6",
-      "description": "Generated test vector #934",
-      "expected": [
-        "triumph",
-        "success",
-        "panther",
-        "clump",
-        "bounty"
-      ]
-    },
-    {
-      "address": "5gqv8eJIBZQhTMkYK05PzuVoKRyIVNHNquLdiVoo",
-      "description": "Generated test vector #935",
-      "expected": [
-        "chest",
-        "bird",
-        "design",
-        "wide",
-        "group"
-      ]
-    },
-    {
-      "address": "osmo1FC73OqOOYgAPbt4EmRjzqKPdWPZLdDuOOlK4MTfuqHYIMhMFuFHDKcc1AI",
-      "description": "Generated test vector #936",
-      "expected": [
-        "dance",
-        "ecology",
-        "upbeat",
-        "matter",
-        "mountain"
-      ]
-    },
-    {
-      "address": "vHb2O9ZIPwXe4rnVPttj4hvYRxNFRHALagRIhn1qlM8rDci4hQyO4tq",
-      "description": "Generated test vector #937",
-      "expected": [
-        "puzzle",
-        "wins",
-        "original",
-        "boring",
-        "digital"
-      ]
-    },
-    {
-      "address": "5Mw7Q3ZHECp3dQnBPL6fWdSZpNtVeaqWc",
-      "description": "Generated test vector #938",
-      "expected": [
-        "antique",
-        "that",
-        "senior",
-        "ratified",
-        "lady"
-      ]
-    },
-    {
-      "address": "3mt1Dvp9Z9WU50x7wwiFI62wSAx9FGOt8Dndkvzq",
-      "description": "Generated test vector #939",
-      "expected": [
-        "biology",
-        "cure",
-        "split",
-        "keypair",
-        "alarm"
-      ]
-    },
-    {
-      "address": "bc1qrMvKN8rCrhRxuUnmcLugegyhHB2OvIkJ6Pp5jePC7",
-      "description": "Generated test vector #940",
-      "expected": [
-        "pioneer",
-        "water",
-        "dance",
-        "joyful",
-        "notable"
-      ]
-    },
-    {
-      "address": "qzkfagQBWsYxZH81GLB9nzVD9mNWy6HnFfN",
-      "description": "Generated test vector #941",
-      "expected": [
-        "resemble",
-        "enlightened",
-        "reward",
-        "pioneer",
-        "shimmering"
-      ]
-    },
-    {
-      "address": "1PXx7tPHlWztS4BIcW1me9bt0siMXUsuwV6AtJ0NzfcGBnWRoKtkoUqKkkwG7lv",
-      "description": "Generated test vector #942",
-      "expected": [
-        "spray",
-        "then",
-        "property",
-        "glee",
-        "cactus"
-      ]
-    },
-    {
-      "address": "qzk4V9YCVu4rhYmEdmCN7iUcxW0yZqmQaO",
-      "description": "Generated test vector #943",
-      "expected": [
-        "act",
-        "sister",
-        "bird",
-        "alpha",
-        "crisp"
-      ]
-    },
-    {
-      "address": "5pwrSNKH6ckjwSfQ7ov2DOP5wqUOHkd2iSprD2p355X",
-      "description": "Generated test vector #944",
-      "expected": [
-        "memory",
-        "dragon",
-        "hydra",
-        "donkey",
-        "galore"
-      ]
-    },
-    {
-      "address": "bc1qV379LawGLD0kqFcxI39nu6yFKdVI",
-      "description": "Generated test vector #945",
-      "expected": [
-        "aid",
-        "win",
-        "increase",
-        "undefeated",
-        "brush"
-      ]
-    },
-    {
-      "address": "bc1qsWJc2SE7Z04aMThNaPap2wgYaz0vuKL7cyHyK1USkklpbyQJ1Z0D0T",
-      "description": "Generated test vector #946",
-      "expected": [
-        "lamp",
-        "unfazed",
-        "flawless",
-        "multiply",
-        "friend"
-      ]
-    },
-    {
-      "address": "bc1qVvePX08jdZHgYnIQ4VqSiruiqKkojQVdblB6kOjPuNZJSookux",
-      "description": "Generated test vector #947",
-      "expected": [
-        "diligent",
-        "panda",
-        "village",
-        "forum",
-        "prudence"
-      ]
-    },
-    {
-      "address": "qzklrTGzExdVU3KCJwx4alNcdp5xh64SuDSAE5WAKsYPJR1mTls6jrkj",
-      "description": "Generated test vector #948",
-      "expected": [
-        "zoo",
-        "text",
-        "volume",
-        "sense",
-        "potato"
-      ]
-    },
-    {
-      "address": "360mSfF5kku9xEbKR5YcSfret5l9pwBbPNnR4Rvr",
-      "description": "Generated test vector #949",
-      "expected": [
-        "weekend",
-        "astound",
-        "talk",
-        "online",
-        "govern"
-      ]
-    },
-    {
-      "address": "3m7rvmvYT5oSBNKWe45bpcNqIwvF9v4ilRlaaA3ILs",
-      "description": "Generated test vector #950",
-      "expected": [
-        "gripping",
-        "alcohol",
-        "school",
-        "cabin",
-        "witty"
-      ]
-    },
-    {
-      "address": "cosmos1QrSUkMqpwO1cNxiZC65akYQwXPqMXUdUwTlseAzANbOJqdty",
-      "description": "Generated test vector #951",
-      "expected": [
-        "dentist",
-        "body",
-        "wild",
-        "pool",
-        "ski"
-      ]
-    },
-    {
-      "address": "qzkpAq00umSbt0Tize9sdP3VZDv3SlhL",
-      "description": "Generated test vector #952",
-      "expected": [
-        "mightily",
-        "jellyfish",
-        "throw",
-        "pyramid",
-        "divide"
-      ]
-    },
-    {
-      "address": "osmo1HOb4To8e9kwTVrBBCAOPskz6oCObGTTTgs0rVxLshgFtKbrKZOW",
-      "description": "Generated test vector #953",
-      "expected": [
-        "ardor",
-        "renew",
-        "venue",
-        "giraffe",
-        "purity"
-      ]
-    },
-    {
-      "address": "0xkle0sJ9rLb7r3feCPr8eXwafTFIczVBYOqqo6ubvqiCdjvoyguh4A1Df",
-      "description": "Generated test vector #954",
-      "expected": [
-        "surround",
-        "ball",
-        "rebuild",
-        "decent",
-        "dwarf"
-      ]
-    },
-    {
-      "address": "bc1qMqcg17apRE6vhREEejBtbOsYUsbGScLPhVoocP5KOJWZKgVZV",
-      "description": "Generated test vector #955",
-      "expected": [
-        "together",
-        "joyous",
-        "voyage",
-        "add",
-        "swim"
-      ]
-    },
-    {
-      "address": "0xhZ1CR9KP0NGB3TuK4MXqlRYjANDHSM003I2ceVJTRDYlTEEGPCFaaQi7FXNf",
-      "description": "Generated test vector #956",
-      "expected": [
-        "cereal",
-        "squeeze",
-        "easy",
-        "rosy",
-        "hand"
-      ]
-    },
-    {
-      "address": "bc1qUgwJdlpAfSNbB8jYuhiN2dQ4zKW80bqPMUlO6D",
-      "description": "Generated test vector #957",
-      "expected": [
-        "liquid",
-        "galaxy",
-        "step",
-        "tomorrow",
-        "logic"
-      ]
-    },
-    {
-      "address": "qzkUbGoXnKOvyRNEaSvGbcZdLIcMlcSVZv8wAsXKUW0",
-      "description": "Generated test vector #958",
-      "expected": [
-        "museum",
-        "decrypt",
-        "jelly",
-        "buoyant",
-        "idea"
-      ]
-    },
-    {
-      "address": "cosmos1zyxRKUK8BfhNg3t2nEqai6BrZR8VAubQPclE",
-      "description": "Generated test vector #959",
-      "expected": [
-        "aspiration",
-        "piece",
-        "sustain",
-        "brother",
-        "soul"
-      ]
-    },
-    {
-      "address": "bc1quBNPiktSpIcmKnEIBwy60VuetqR8rLia",
-      "description": "Generated test vector #960",
-      "expected": [
-        "giraffe",
-        "enter",
-        "best",
-        "age",
-        "gospel"
-      ]
-    },
-    {
-      "address": "1dHVSmH1hpi1F0pgVaQbCEGYv2yIEyt3cnKUR2SA",
-      "description": "Generated test vector #961",
-      "expected": [
-        "dune",
-        "vested",
-        "well",
-        "sweet",
-        "grocery"
-      ]
-    },
-    {
-      "address": "3Q9Q2igvWX6kxUlO0zSK3RKxFyp8JnlK8v27Gk",
-      "description": "Generated test vector #962",
-      "expected": [
-        "find",
-        "split",
-        "lobster",
-        "lumber",
-        "merge"
-      ]
-    },
-    {
-      "address": "IzWspT0PV4xNc8duvWDsynGnpSaj5kE6v0sSOtW3jUAzaGLc",
-      "description": "Generated test vector #963",
-      "expected": [
-        "nourish",
-        "solar",
-        "blade",
-        "fair",
-        "obvious"
-      ]
-    },
-    {
-      "address": "0x6At2BQRiwAIUnYpNcOSMboJyG4Ux6yUG9sG9iSX9lI31v6bb3Xgc",
-      "description": "Generated test vector #964",
-      "expected": [
-        "kiwi",
-        "bench",
-        "nominee",
-        "wear",
-        "sincere"
-      ]
-    },
-    {
-      "address": "cosmos1RG6edSNo75rtlGLOpqfmWIgOURivC4n0cmwPOXBABuaWlUE4N3xdn1m9",
-      "description": "Generated test vector #965",
-      "expected": [
-        "debris",
-        "vocal",
-        "artwork",
-        "advice",
-        "hospital"
-      ]
-    },
-    {
-      "address": "1lpr9VfAnMBRNFVXjROzHeGRQUDdxq4bEpfxbSdTjzFm0uL",
-      "description": "Generated test vector #966",
-      "expected": [
-        "scout",
-        "intricate",
-        "maze",
-        "lumber",
-        "dog"
-      ]
-    },
-    {
-      "address": "5BpYIDxqis9Vrhlq2WGWzwYV7lnPDyCVvZaWK8",
-      "description": "Generated test vector #967",
-      "expected": [
-        "this",
-        "hamster",
-        "raise",
-        "hamster",
-        "strategy"
-      ]
-    },
-    {
-      "address": "bc1qwwoOMkQ1qcpq1w2RL8R7eIOxQLZd1FuS1Gd2VGq8WniKQCSIt2krj3",
-      "description": "Generated test vector #968",
-      "expected": [
-        "dawn",
-        "eloquence",
-        "wealth",
-        "episode",
-        "venerate"
-      ]
-    },
-    {
-      "address": "cosmos1VsAGR3M7NcSy306kkBCgBCD6f3h2jTn50oGEdbNneQhA1SAtPySGJTD5k",
-      "description": "Generated test vector #969",
-      "expected": [
-        "coyote",
-        "work",
-        "wet",
-        "trim",
-        "eager"
-      ]
-    },
-    {
-      "address": "1itJNlpz85AcQg0fqPwLuHQltjF8bMseWovhrZYfe2GllehJffLaZADAPm1mXy",
-      "description": "Generated test vector #970",
-      "expected": [
-        "tortoise",
-        "pledge",
-        "release",
-        "silk",
-        "indicate"
-      ]
-    },
-    {
-      "address": "cosmos1pmysv917pRTSkTcj6RBVKsKL0VUDoRDwHSwmc3Xnty4",
-      "description": "Generated test vector #971",
-      "expected": [
-        "away",
-        "mechanic",
-        "organ",
-        "believe",
-        "usable"
-      ]
-    },
-    {
-      "address": "bc1q2MFX8BAA0sPS3FhP5mizBlibYWr1JjLieMkB7NXvAPHkJTFihib",
-      "description": "Generated test vector #972",
-      "expected": [
-        "album",
-        "skirt",
-        "replace",
-        "sound",
-        "action"
-      ]
-    },
-    {
-      "address": "SMlU824g3W6Qwvs9eIUS8F6cT1a8QR1GeRmY3no",
-      "description": "Generated test vector #973",
-      "expected": [
-        "savings",
-        "fond",
-        "calm",
-        "shop",
-        "fossil"
-      ]
-    },
-    {
-      "address": "0xEmg2h9quNOMJVDTgx92Xc1osEz7Jb0wJHmy3939AGgf3ZnTbxn",
-      "description": "Generated test vector #974",
-      "expected": [
-        "fame",
-        "reason",
-        "tap",
         "describe",
-        "lifesaver"
-      ]
-    },
-    {
-      "address": "cosmos1N8O3EhaKchmmN8bnXvAkt9IUI7YH1sKczIRu8gzTkr03NB",
-      "description": "Generated test vector #975",
-      "expected": [
-        "ticket",
-        "derive",
-        "tough",
-        "pretty",
-        "mammal"
-      ]
-    },
-    {
-      "address": "cosmos1eNmmgaFWeyVEQMQweFZP0x2cRlqKc",
-      "description": "Generated test vector #976",
-      "expected": [
-        "way",
-        "street",
-        "godsend",
-        "alter",
-        "flash"
-      ]
-    },
-    {
-      "address": "KiVWZuFmS7cDnDUjwIIJQGmdpCIXpbKQhqtUIp0xEccrYsOSVTQPFg2KQkupJj0",
-      "description": "Generated test vector #977",
-      "expected": [
-        "very",
-        "stirring",
-        "give",
-        "vigor",
-        "never"
-      ]
-    },
-    {
-      "address": "5qgj7VW8Hd4dliuKgXgf0FopRLU5iPYiyW9",
-      "description": "Generated test vector #978",
-      "expected": [
-        "dextrous",
-        "topic",
-        "spend",
-        "bike",
-        "skill"
-      ]
-    },
-    {
-      "address": "cosmos1fRNadRnRhCZuw9O4lHO9lFgor3kFUqLd8F9TWaTwM4TqGeHyuBlbFlr5",
-      "description": "Generated test vector #979",
-      "expected": [
-        "sun",
-        "attend",
-        "node",
-        "dove",
-        "burst"
-      ]
-    },
-    {
-      "address": "0xK44T4JUUfvftw8wMpMifmIiWDNkHPbje59xWOpqcM0Fg9gwVxSo",
-      "description": "Generated test vector #980",
-      "expected": [
-        "quantum",
-        "atom",
-        "revolution",
-        "significant",
-        "gown"
-      ]
-    },
-    {
-      "address": "bc1q2reahnrstfpNF2b0u4iiDD6hdsCMO",
-      "description": "Generated test vector #981",
-      "expected": [
-        "voice",
-        "family",
-        "document",
-        "doll",
-        "galaxy"
-      ]
-    },
-    {
-      "address": "RvPBWenaBArMCRRlJF6B4MrtOWNhfi0ZY8Ti7wJnO4nIYog36Az12DQ4zE",
-      "description": "Generated test vector #982",
-      "expected": [
-        "venerate",
-        "office",
-        "hospital",
-        "country",
-        "dedicated"
-      ]
-    },
-    {
-      "address": "qzkg9YJ3XhE3hK4Etw5ylsn1SsXH8ST0BYCIv",
-      "description": "Generated test vector #983",
-      "expected": [
-        "blossom",
-        "swarm",
-        "project",
-        "all",
-        "rabbit"
-      ]
-    },
-    {
-      "address": "0xPwRMe80GNrdTZVLktoLmy7rHy9ChGzGTSNsBrz8Txh3QpNgGXGtE1hnuM2vPL",
-      "description": "Generated test vector #984",
-      "expected": [
-        "gaze",
-        "believe",
-        "divine",
-        "grand",
-        "estate"
-      ]
-    },
-    {
-      "address": "0xLSDBdtNun9emWqjkvkNJIxQqwvOMuZErGAjOtj2qBjUWbhrasJckvS72g",
-      "description": "Generated test vector #985",
-      "expected": [
-        "payment",
-        "cross",
-        "leader",
-        "mist",
-        "mesmerize"
-      ]
-    },
-    {
-      "address": "cosmos1Ccz6BxdojhJy0MWdTAvyJ4hS84Gqvnp4e4bc3kHxzcdWi6fwRZtLDX3",
-      "description": "Generated test vector #986",
-      "expected": [
-        "homage",
-        "spread",
-        "squeeze",
-        "wild",
-        "soap"
-      ]
-    },
-    {
-      "address": "5uAo6Qn3lEcreQ5CkIp5LuFly5kTcEy",
-      "description": "Generated test vector #987",
-      "expected": [
-        "express",
-        "furnace",
-        "hotel",
-        "title",
-        "country"
-      ]
-    },
-    {
-      "address": "qzkBnF2dgYcvQJ6Gw7jCuqXXyplrQypc05SzyUutCpOJdh2PexZUtPejLAUOwsK",
-      "description": "Generated test vector #988",
-      "expected": [
-        "age",
-        "bloom",
-        "almost",
-        "remunerate",
-        "snazzy"
-      ]
-    },
-    {
-      "address": "0xmCcMz5catWZoBlUyqu9ysV32fK4tyo1PEehYFhvSQl7e",
-      "description": "Generated test vector #989",
-      "expected": [
-        "bread",
-        "dice",
-        "peerless",
-        "cost",
-        "seek"
-      ]
-    },
-    {
-      "address": "cosmos1Vi0ivHeBXD5fzQkP1503G1oAEIoPcmY",
-      "description": "Generated test vector #990",
-      "expected": [
-        "moment",
-        "blossom",
-        "library",
-        "upon",
-        "bring"
-      ]
-    },
-    {
-      "address": "bc1qFyNvNlyGxGHbKzobli9amzYr2MIonXqQnDBkZokizSFrJqEz2LTV6T2F",
-      "description": "Generated test vector #991",
-      "expected": [
-        "raven",
-        "box",
-        "knock",
-        "invest",
-        "fork"
-      ]
-    },
-    {
-      "address": "3bDXFWMvFNP5PbXYbHSqMoSB9WuhELiEXQSEljX9otWy1l2J4",
-      "description": "Generated test vector #992",
-      "expected": [
-        "tact",
-        "excite",
-        "stone",
-        "extra",
-        "olympic"
-      ]
-    },
-    {
-      "address": "cosmos1fRyY9WAHk7ZW2nKAS66ZujJys7eQFn3OClJKfqy51W6AR1",
-      "description": "Generated test vector #993",
-      "expected": [
-        "premier",
-        "include",
-        "wins",
-        "final",
-        "ride"
-      ]
-    },
-    {
-      "address": "osmo18CTA2wMUe7xZKzTix8JJXQ0oPTmQ8",
-      "description": "Generated test vector #994",
-      "expected": [
-        "zen",
-        "idyllic",
-        "globe",
-        "cool",
-        "will"
-      ]
-    },
-    {
-      "address": "cosmos10jmEDq3ji1QiOYX0lFP2QboBgubk5",
-      "description": "Generated test vector #995",
-      "expected": [
-        "elevator",
-        "art",
-        "episode",
-        "team",
-        "royal"
-      ]
-    },
-    {
-      "address": "TuFmkgsm7fnOT9R9eBePNd9oXVqMR21n6N6ksEzJiPc5i",
-      "description": "Generated test vector #996",
-      "expected": [
-        "sun",
-        "inch",
-        "ladder",
-        "tolerant",
-        "sea"
-      ]
-    },
-    {
-      "address": "cosmos1VQkFsCPz78UPFfUwsLgspzgnGAWzQ0fgZtoCbUXZxeEq",
-      "description": "Generated test vector #997",
-      "expected": [
-        "abundance",
-        "cover",
-        "account",
-        "into",
-        "superb"
-      ]
-    },
-    {
-      "address": "0xL4xoegWYK1PyViKBidfALeUgxB5NtQIQEq32Liwph8uayggRHT5dLC",
-      "description": "Generated test vector #998",
-      "expected": [
-        "lemon",
-        "interest",
-        "chime",
-        "yield",
-        "hotel"
-      ]
-    },
-    {
-      "address": "5uvzKdspwOdvmPdFOjUlhnM9EnZt5HQwJ2CWzFFyXJiSRqEzAkEeY7B17vUv",
-      "description": "Generated test vector #999",
-      "expected": [
-        "able",
-        "bullish",
-        "serene",
-        "unfazed",
-        "wish"
-      ]
-    },
-    {
-      "address": "bc1q5YAJMFOLHoXLTRGuMhJRVsntJhjepS8cy0j4I7EcbWj",
-      "description": "Generated test vector #1000",
-      "expected": [
-        "camel",
-        "verify",
-        "achieve",
-        "amazing",
-        "famous"
-      ]
-    },
-    {
-      "address": "qzk9WmpCxYYdC72JLtPabRvY4MrEZ7rXgTqSddjjditUnblQcWfB3ZBMdvw",
-      "description": "Generated test vector #1001",
-      "expected": [
-        "symptom",
-        "deer",
-        "approve",
-        "energy",
-        "grass"
-      ]
-    },
-    {
-      "address": "1QTMmrQoUN7R4CHYZg0jXP2PJ7e5CNGPPZH6d5oHoyJDaPXPwLtWAqdeOlsWR",
-      "description": "Generated test vector #1002",
-      "expected": [
-        "jubilant",
-        "steel",
-        "forum",
-        "ability",
-        "upscale"
-      ]
-    },
-    {
-      "address": "5KDXcsi19KaWNFkrgchXO6nMfEPmc940TDkRNEn5GoFVcM",
-      "description": "Generated test vector #1003",
-      "expected": [
-        "evolve",
-        "poem",
-        "tray",
-        "alive",
-        "exit"
-      ]
-    },
-    {
-      "address": "osmo1M5Ezwrkf7adkF6ZqCWxrNuYyZhUpSc0gq5",
-      "description": "Generated test vector #1004",
-      "expected": [
-        "marble",
-        "feature",
-        "milk",
-        "inquiry",
-        "cement"
-      ]
-    },
-    {
-      "address": "34kEY6ALej0JFYlV9sMkcxKYwYHf5JEJgz0",
-      "description": "Generated test vector #1005",
-      "expected": [
-        "owl",
-        "sunset",
-        "dry",
-        "hip",
-        "zoo"
-      ]
-    },
-    {
-      "address": "0x2cxsbiBdPhgi0wbcn1Uv1oW99oqX8YfQq4",
-      "description": "Generated test vector #1006",
-      "expected": [
-        "inner",
-        "zoo",
-        "repeat",
-        "cluster",
-        "whole"
-      ]
-    },
-    {
-      "address": "qzkSZOedAu7yWnRVS3qefelcpRbCGzCdCXonN8XX",
-      "description": "Generated test vector #1007",
-      "expected": [
-        "someone",
-        "census",
-        "cousin",
-        "awake",
-        "dad"
-      ]
-    },
-    {
-      "address": "1Q3BvpCUn0G0VjWkDx7pTNh1VVrAsMOlTSjgsxu07s3m9",
-      "description": "Generated test vector #1008",
-      "expected": [
-        "grin",
-        "miracle",
-        "worth",
-        "bag",
-        "remain"
-      ]
-    },
-    {
-      "address": "bc1qvLjewCSzcWx3BNb2YLWi2wc6IfbJqn",
-      "description": "Generated test vector #1009",
-      "expected": [
-        "noiseless",
-        "lobster",
-        "diplomat",
-        "ensure",
-        "flexible"
-      ]
-    },
-    {
-      "address": "osmo1xJZbvRHxhUK0nJX5TaUMhvvmuO1wQCYPnkwtG0Yh9T",
-      "description": "Generated test vector #1010",
-      "expected": [
-        "milk",
-        "next",
-        "draw",
-        "guitar",
-        "gem"
-      ]
-    },
-    {
-      "address": "1BhomIz3ZNhfAtnEHe5o62n3PQfdvYHV9u",
-      "description": "Generated test vector #1011",
-      "expected": [
-        "kidney",
-        "beach",
-        "wombat",
-        "twenty",
-        "evenly"
-      ]
-    },
-    {
-      "address": "3nArPmhfjNM5AHSDsPDutyBiQB66cxMg5hTt1yu1sAYog4fxNHtbx0gcSOap",
-      "description": "Generated test vector #1012",
-      "expected": [
-        "exchange",
-        "ring",
-        "output",
-        "blush",
-        "spatial"
-      ]
-    },
-    {
-      "address": "bc1q1fAWZiT8MB0wV6V2YN13o8BQCtf13QpK3UVG9daP4c",
-      "description": "Generated test vector #1013",
-      "expected": [
-        "unique",
-        "star",
-        "champion",
-        "posh",
-        "shrimp"
-      ]
-    },
-    {
-      "address": "bc1qTFDQ5EQ5Y4nPBy3Rf65DXE4MGFs0MSM2CKfsLC70zOL5K4k",
-      "description": "Generated test vector #1014",
-      "expected": [
-        "tooth",
-        "likable",
-        "restful",
-        "farm",
-        "split"
-      ]
-    },
-    {
-      "address": "2y0VWD0OT6T7Nlcgi3HiR33V9TEJonqd15KYMANNfykfvdA5GQWBZ5nFRBf2",
-      "description": "Generated test vector #1015",
-      "expected": [
-        "cliff",
-        "slide",
-        "present",
-        "category",
-        "nothing"
-      ]
-    },
-    {
-      "address": "5P55k4WSdyjSzNlfdzC8YHzBSRDHeLw",
-      "description": "Generated test vector #1016",
-      "expected": [
-        "funny",
-        "invulnerable",
-        "next",
-        "cushion",
-        "avid"
-      ]
-    },
-    {
-      "address": "osmo1ocjaCwd00X8LVQRpHctpoIOQhA3eV2E2dy14Q6w2",
-      "description": "Generated test vector #1017",
-      "expected": [
-        "across",
-        "area",
-        "actress",
-        "fine",
-        "gush"
-      ]
-    },
-    {
-      "address": "1YGEcYOdZ8QJLZjriB9GLJJiJ6aNIdiFcx",
-      "description": "Generated test vector #1018",
-      "expected": [
-        "early",
-        "clown",
-        "immaculate",
-        "vivid",
-        "saddle"
-      ]
-    },
-    {
-      "address": "0xUJjzqTv9JuMIHq7Ko6ZvteV4N6QxFsDuxn15cx9K",
-      "description": "Generated test vector #1019",
-      "expected": [
-        "pigeon",
-        "tell",
-        "eyebrow",
-        "joy",
-        "flex"
-      ]
-    },
-    {
-      "address": "3onu6OUmOfmQmAY63kFDsCZWBUoMXgVeR1I2vHPG6YPhNURQsGtq1mDJAUvvEJ0",
-      "description": "Generated test vector #1020",
-      "expected": [
-        "bounty",
-        "amateur",
-        "husband",
-        "vigilant",
-        "spend"
-      ]
-    },
-    {
-      "address": "4g85zoiUUhqmDuctZyHBIYV7QNVglHl4RyuXzQmSYIlc2vfCkRgs",
-      "description": "Generated test vector #1021",
-      "expected": [
-        "euphoria",
-        "high",
-        "series",
-        "influential",
-        "bus"
-      ]
-    },
-    {
-      "address": "cosmos1swdvPRPDqkLynzelXsiQQRTlvLSar",
-      "description": "Generated test vector #1022",
-      "expected": [
-        "camera",
-        "kudos",
-        "cause",
-        "obvious",
-        "peerless"
-      ]
-    },
-    {
-      "address": "bc1q5wKFL9UQjzAfsnKZbm76QheYNmYxEm",
-      "description": "Generated test vector #1023",
-      "expected": [
-        "future",
-        "real",
-        "audit",
-        "gift",
-        "laud"
-      ]
-    },
-    {
-      "address": "cosmos12RuUskFNn2QZFtlSBLnp0wBtoNvhLaQs7ri56TerjqCm2Cugm",
-      "description": "Generated test vector #1024",
-      "expected": [
-        "mirth",
-        "human",
-        "act",
-        "outwit",
-        "course"
-      ]
-    },
-    {
-      "address": "qzk7OJp1Ph6Mm55k5Tl26qtryzOVLAO",
-      "description": "Generated test vector #1025",
-      "expected": [
-        "rotate",
-        "sphere",
-        "vacuum",
-        "profit",
-        "grocery"
-      ]
-    },
-    {
-      "address": "qzkpmM99Ur7dro2BZKJ27iG8OVgWfxnQzlZGGu16OAiFma3tSscD5k0u",
-      "description": "Generated test vector #1026",
-      "expected": [
-        "ultimate",
-        "essay",
-        "act",
-        "honor",
-        "jungle"
-      ]
-    },
-    {
-      "address": "H0zFPPNTlapriK20HnZhQeo3HZaaap52vtT3JZgs2ATjvH",
-      "description": "Generated test vector #1027",
-      "expected": [
-        "steadfast",
-        "poignant",
-        "safe",
-        "rejuvenate",
-        "focus"
-      ]
-    },
-    {
-      "address": "osmo1LSQR5WQMwqHM5HfNfiukBYccH8uutksZeUXU",
-      "description": "Generated test vector #1028",
-      "expected": [
-        "prepare",
-        "work",
-        "fetch",
-        "bag",
-        "guitar"
-      ]
-    },
-    {
-      "address": "0xlPn3r8lWoC54AD56yHmlhVFjOIFIcEw15BvvUIysfRliJqHhOP7fvlG8m",
-      "description": "Generated test vector #1029",
-      "expected": [
-        "chic",
-        "hen",
-        "accurate",
-        "bliss",
-        "title"
-      ]
-    },
-    {
-      "address": "1IDyqMqIDEs6WKOe8beH097lEJzdzHXPBSr",
-      "description": "Generated test vector #1030",
-      "expected": [
-        "success",
-        "soap",
-        "pink",
-        "nephew",
-        "skirt"
-      ]
-    },
-    {
-      "address": "cosmos1I8TLx5bsG8Yj0sSu35KE9qs48fTQXQc6CKQZKfeilUvfi",
-      "description": "Generated test vector #1031",
-      "expected": [
-        "stairs",
-        "moral",
-        "cure",
-        "priority",
-        "wieldy"
-      ]
-    },
-    {
-      "address": "exru0SPkoaV1CDedck7ADr2FrjCpGA9nWY9i9HPvpBA3oUHHeAUV",
-      "description": "Generated test vector #1032",
-      "expected": [
-        "surface",
-        "code",
-        "jungle",
-        "spread",
-        "fragrant"
-      ]
-    },
-    {
-      "address": "osmo1FDxQRDclNLylUkIBk07HEAzTWNJExMtSaTNIzNqU9ozlube",
-      "description": "Generated test vector #1033",
-      "expected": [
-        "endorse",
-        "exercise",
-        "silver",
-        "welcome",
-        "inch"
-      ]
-    },
-    {
-      "address": "qzklFEgUoYlluSPHnDW4Ni9SqcvhEwHAYeRdbvf9GxNqLo",
-      "description": "Generated test vector #1034",
-      "expected": [
-        "depth",
-        "unbeatable",
-        "enrich",
-        "gaze",
-        "project"
-      ]
-    },
-    {
-      "address": "0x2BEtUqDMFNaXbaZodZNSrHb4eT3ZVJgOITejV6qpBArxG52tI3xQHZmyuVt",
-      "description": "Generated test vector #1035",
-      "expected": [
-        "economy",
-        "verb",
-        "wink",
-        "merry",
-        "time"
-      ]
-    },
-    {
-      "address": "qzkXF388W6KYuUYyUdGnYbLKeRLTzlPfTntMIE3C",
-      "description": "Generated test vector #1036",
-      "expected": [
-        "small",
-        "alight",
-        "output",
-        "badge",
-        "there"
-      ]
-    },
-    {
-      "address": "181LR8UiV4n2A1Vgn5OkwzJEyQJaMfDM4jo8u",
-      "description": "Generated test vector #1037",
-      "expected": [
-        "finger",
-        "scene",
-        "captain",
-        "candy",
-        "buyer"
-      ]
-    },
-    {
-      "address": "qzkrp7Av52QQaUIT1IckSN0KFl9JikhOXqiNQEfd",
-      "description": "Generated test vector #1038",
-      "expected": [
-        "mist",
-        "host",
-        "security",
-        "dedicated",
-        "usage"
-      ]
-    },
-    {
-      "address": "33qLp7m8rqGLe7zuMfHn59lyKVyxb4RR",
-      "description": "Generated test vector #1039",
-      "expected": [
-        "title",
-        "square",
-        "delectable",
-        "yes",
-        "brain"
-      ]
-    },
-    {
-      "address": "qzkaIJb6rFdBdgMwbXuk0HuSrqQSmlG1TxSpJp47gj9GFhD5NIx9",
-      "description": "Generated test vector #1040",
-      "expected": [
-        "rebuild",
-        "hint",
-        "sword",
-        "include",
-        "hen"
-      ]
-    },
-    {
-      "address": "bc1qdLcYbMGCApSu4HfTZOkBz20HBFqhyAR8d16Xv",
-      "description": "Generated test vector #1041",
-      "expected": [
-        "chimney",
-        "grab",
-        "degree",
-        "nautilus",
-        "brief"
-      ]
-    },
-    {
-      "address": "bc1qcc1bQqcYl5tvxzYSfm0wDNiVWoJlLk",
-      "description": "Generated test vector #1042",
-      "expected": [
-        "just",
-        "fit",
-        "youth",
-        "sword",
-        "turn"
-      ]
-    },
-    {
-      "address": "bc1qtGH5E9LSBCXtnvKkJpoe2VvoCKQ2eecFQCQhj",
-      "description": "Generated test vector #1043",
-      "expected": [
-        "unfold",
-        "thumb",
-        "invite",
-        "lucky",
-        "bid"
-      ]
-    },
-    {
-      "address": "3NqqJrCXXHGWyM2t8eqhwiUfiSDnWfoHBWPhVnLtw5N",
-      "description": "Generated test vector #1044",
-      "expected": [
-        "raccoon",
-        "unbound",
-        "allow",
-        "inestimable",
-        "chef"
-      ]
-    },
-    {
-      "address": "gyQ63SGrtmtOUA61VAW8ObNEqib2OY",
-      "description": "Generated test vector #1045",
-      "expected": [
-        "neck",
-        "pitch",
-        "amused",
-        "flying",
-        "cube"
-      ]
-    },
-    {
-      "address": "1aFUWCYV0eRyKjK5mNKMyGPtDzoaM8KDNggt9JV3sC6xYC",
-      "description": "Generated test vector #1046",
-      "expected": [
-        "tourist",
-        "area",
-        "magnet",
-        "action",
+        "hand",
+        "upheld",
+        "empower",
         "special"
       ]
     },
     {
-      "address": "1uWrzx7IZmBxoe8h7XwY9ieEAEEkzpTmua0bOXImhqPeefTcfCsqI9QJf",
-      "description": "Generated test vector #1047",
+      "address": "osmo13q6Q4EmT2mmpMjg5PPMVHcDME931E94rnJdXDH",
+      "description": "Generated test vector #91",
       "expected": [
-        "paper",
-        "attitude",
-        "rejuvenate",
-        "tower",
-        "relax"
+        "round",
+        "intuitive",
+        "claim",
+        "yellow",
+        "special"
       ]
     },
     {
-      "address": "cosmos1lFlepXHqWUFbEKCNwqlRkrPQdkMgtXs",
-      "description": "Generated test vector #1048",
+      "address": "yQk8RCQanKuLqIoDMwEnRx0rliJogqoAxj7jXkE90GSWsIJyQdYD",
+      "description": "Generated test vector #92",
       "expected": [
-        "wolf",
-        "unlock",
-        "bolster",
-        "topple",
-        "regal"
-      ]
-    },
-    {
-      "address": "qzkyNZA3V1pGaQaNKHADXiqttajlkhHybXtHn8k3",
-      "description": "Generated test vector #1049",
-      "expected": [
-        "cooperate",
-        "load",
-        "sage",
-        "hottest",
-        "soap"
-      ]
-    },
-    {
-      "address": "3NiZGMiG2RJHnJNAb6ZI44VH0J4UHDCxLHz2pZKhv",
-      "description": "Generated test vector #1050",
-      "expected": [
-        "kangaroo",
-        "rebel",
-        "sunny",
-        "mango",
-        "polar"
-      ]
-    },
-    {
-      "address": "WKEAr8WMJVDlVuUL494fab0Do29G8TmNeHQc4ldFMoPj8qswOv8V46B4R",
-      "description": "Generated test vector #1051",
-      "expected": [
-        "elder",
-        "school",
-        "hamster",
-        "liberty",
-        "garment"
-      ]
-    },
-    {
-      "address": "cosmos1Mn9vnz3HXGsOSTEM9gsuMaSqMA",
-      "description": "Generated test vector #1052",
-      "expected": [
-        "bubble",
-        "retire",
-        "asset",
-        "orbit",
-        "thing"
-      ]
-    },
-    {
-      "address": "bc1qaAzD5aRZ7CCiMSErayrPwpQle6wuPuGIeNJYHZSciZowdPV29NlM5Tvp7DOX",
-      "description": "Generated test vector #1053",
-      "expected": [
-        "pilot",
-        "equal",
-        "narrow",
-        "grocery",
-        "grape"
-      ]
-    },
-    {
-      "address": "3iUlGgPVDQhC4syHsIxJEuCV4fimhtQqEkZrN07nvsxITRGJ",
-      "description": "Generated test vector #1054",
-      "expected": [
-        "tranquil",
-        "everlasting",
-        "conduct",
-        "intricate",
-        "gallery"
-      ]
-    },
-    {
-      "address": "52fILdeFZK4ZT2FNwzOqddN8WzVDLvpV02WTWL2SfTQPkRbYDpvCMi",
-      "description": "Generated test vector #1055",
-      "expected": [
-        "equal",
-        "result",
-        "orangutan",
-        "cake",
-        "noiseless"
-      ]
-    },
-    {
-      "address": "1SCdhoJPqYvqJK1Ks3LNOhhDkei3tsfkkQ00FN4ObhUvQnfJhbOKlyZh1jMqOJ",
-      "description": "Generated test vector #1056",
-      "expected": [
-        "oak",
-        "yard",
-        "subsidize",
-        "nature",
-        "glimpse"
-      ]
-    },
-    {
-      "address": "osmo12Xri86lymTaneeAHHC7WQcZuutyQUnmRPh4iOik148ldEU7IlbNB6",
-      "description": "Generated test vector #1057",
-      "expected": [
-        "any",
-        "crater",
-        "faultless",
-        "wonder",
-        "gossip"
-      ]
-    },
-    {
-      "address": "bc1qS4fouBRYUTNRvaliZMM3emar22SP3dSDsN5foji2zAto0VIfIQSnpmoAC",
-      "description": "Generated test vector #1058",
-      "expected": [
-        "search",
-        "peanut",
-        "auto",
-        "wolf",
-        "fold"
-      ]
-    },
-    {
-      "address": "bc1qf3thFHt6pvEiLsYFIDEjKFNfLx4L",
-      "description": "Generated test vector #1059",
-      "expected": [
-        "vault",
-        "keen",
-        "victory",
-        "curtain",
-        "ski"
-      ]
-    },
-    {
-      "address": "3fMg2e51lohKJj8YR9CduSRcux9hBEqyZEuh9lmS415XZ54INJ",
-      "description": "Generated test vector #1060",
-      "expected": [
-        "monumental",
-        "truth",
-        "quality",
-        "motion",
-        "accurate"
-      ]
-    },
-    {
-      "address": "0xcWJ5JwtvNgJJb4XEEd7FfokJm7XCdiEiotRiZBNWinpRGIWVWQsek",
-      "description": "Generated test vector #1061",
-      "expected": [
-        "plentiful",
-        "yard",
-        "ritual",
-        "stadium",
-        "comic"
-      ]
-    },
-    {
-      "address": "cosmos1ihZf0ZuOt5UaPURbQyH2EpDQ0EaMN6RNWa",
-      "description": "Generated test vector #1062",
-      "expected": [
-        "saint",
-        "guide",
-        "venerate",
-        "ingenious",
-        "entice"
-      ]
-    },
-    {
-      "address": "bc1qktplPsr5geI7792mOtyqwcjao4GA2ABxyLYFPxm9crUz0l23OaG6YeshF",
-      "description": "Generated test vector #1063",
-      "expected": [
-        "swap",
-        "decide",
-        "tulip",
-        "pond",
-        "unwavering"
-      ]
-    },
-    {
-      "address": "3L6l2fML431K0ZDgV4wqUR7XTeon6yNVrmCrdsi6CUqvyT1guvIeza8tdBEAbV8D",
-      "description": "Generated test vector #1064",
-      "expected": [
-        "ace",
-        "remain",
-        "prepare",
-        "bus",
-        "majestic"
-      ]
-    },
-    {
-      "address": "5qZx3vvT1XCIeNSJKDie5fOhWojD7n3yNMWE8YBGQxKz9EH0PD8qKgN4MVZhXt6",
-      "description": "Generated test vector #1065",
-      "expected": [
-        "squirrel",
-        "invulnerable",
-        "swank",
-        "boost",
-        "hundred"
-      ]
-    },
-    {
-      "address": "1ExQlEjTeWzgHamlV7JsohJHZpeu09PRGkdYeKiHDlBCn6Us0FPFbK",
-      "description": "Generated test vector #1066",
-      "expected": [
-        "fulfill",
-        "resilient",
-        "fearless",
-        "hardy",
-        "flat"
-      ]
-    },
-    {
-      "address": "0xYTMrS2TLCWjp7K9lG06n1COpPuRXwrknqcxIFwudGLNgfaGCHpvZW1KrZR",
-      "description": "Generated test vector #1067",
-      "expected": [
-        "enact",
-        "earn",
-        "beyond",
-        "sister",
-        "shift"
-      ]
-    },
-    {
-      "address": "QZuEEEoF9hBAnlrGYSa56Xj8G1DWrJ9fIf82RQerhMEN4vLxZ2obRA06aD",
-      "description": "Generated test vector #1068",
-      "expected": [
-        "wish",
-        "revolution",
-        "hundred",
         "banner",
-        "blue"
+        "snazzy",
+        "august",
+        "again",
+        "harvest"
       ]
     },
     {
-      "address": "cosmos171s8k105hnx4Os94QbGvvOIkqmP5S948hleSzL4mprJvhMIXOEZDjdoI",
-      "description": "Generated test vector #1069",
+      "address": "1UqwIYvzvQLJOH8ruFWBeMC71N5ALz4evtOSLy3W6UGBk0hopUUnyf6DdV",
+      "description": "Generated test vector #93",
       "expected": [
-        "close",
-        "moon",
-        "husband",
-        "check",
-        "pretty"
+        "turtle",
+        "soul",
+        "upbeat",
+        "toward",
+        "pledge"
       ]
     },
     {
-      "address": "5FF5Z6AcHnHPEWLc0qwmKr7GGDp2ptnE8SaYuo6GJjbm0ca4LxH4y0EFu",
-      "description": "Generated test vector #1070",
+      "address": "gMf5yoTBhGkcw41C15Ii6HKCU2ANH4Doftz",
+      "description": "Generated test vector #94",
       "expected": [
-        "effort",
-        "access",
-        "seat",
-        "employ",
-        "unfold"
-      ]
-    },
-    {
-      "address": "bc1qE7ltIedVYbbpbWXBxb79iPwVHsgiFFkET9EV9j8",
-      "description": "Generated test vector #1071",
-      "expected": [
-        "nautilus",
-        "window",
-        "endear",
-        "incredible",
-        "attend"
-      ]
-    },
-    {
-      "address": "cosmos1OWaC2n3LGc1FR04HUEsBPr46ymOxDJ0JpfeWhke1GvUwH",
-      "description": "Generated test vector #1072",
-      "expected": [
-        "either",
-        "boil",
-        "digital",
-        "network",
-        "course"
-      ]
-    },
-    {
-      "address": "1mXTGxFIkj6gpKSkSJXwbeyOdZfUnjD0lFsr6BBr",
-      "description": "Generated test vector #1073",
-      "expected": [
-        "husband",
-        "lens",
-        "thank",
-        "ship",
-        "mobile"
-      ]
-    },
-    {
-      "address": "cosmos1mgzXfrsZHau1bunTXPLVb8CMQRK1MKXATRog2b05CTu4",
-      "description": "Generated test vector #1074",
-      "expected": [
-        "track",
-        "surround",
-        "hope",
-        "stairs",
-        "announce"
-      ]
-    },
-    {
-      "address": "bc1q7QIMWxMC7YNLvbgHsejT26kGB5M7cH3TyZrJ22TA47jW",
-      "description": "Generated test vector #1075",
-      "expected": [
-        "accurate",
-        "squeeze",
-        "wall",
-        "cube",
-        "dynamic"
-      ]
-    },
-    {
-      "address": "osmo1t4nDYcfTcmv6wJSMLtzwrOEyBpJfsFyK9TrakWkARUmiQSrNhyar",
-      "description": "Generated test vector #1076",
-      "expected": [
-        "authentic",
-        "road",
-        "flavor",
-        "cycle",
-        "unabashed"
-      ]
-    },
-    {
-      "address": "5yiAHjMLKDRFOrWXAQX1PO0HFZwlLLt",
-      "description": "Generated test vector #1077",
-      "expected": [
-        "collect",
-        "darling",
-        "surmount",
-        "chaos",
-        "index"
-      ]
-    },
-    {
-      "address": "3FHQGQ4kBhY0qu5851LxjNPDs44Y57UUyhFWDsck1VOkbWlTi5n1",
-      "description": "Generated test vector #1078",
-      "expected": [
-        "similar",
-        "laugh",
-        "try",
-        "subject",
-        "snazzy"
-      ]
-    },
-    {
-      "address": "1JcbqY1DoCMZ5HfGFf5UB1VbPV53HNQ9cinBDK9Dp03Kx35W",
-      "description": "Generated test vector #1079",
-      "expected": [
-        "add",
-        "atom",
-        "profit",
-        "chair",
-        "try"
-      ]
-    },
-    {
-      "address": "3nUEhIwhjy083BLPxNQDqG1OqyuQsZNN7yFJ68L29eeZTlbrhDun7Gvpvatk",
-      "description": "Generated test vector #1080",
-      "expected": [
-        "flag",
-        "boat",
-        "twenty",
-        "junior",
-        "adequate"
-      ]
-    },
-    {
-      "address": "0xQUO9f5fSSUVrfddnKpZBXhUcXPb2UbZVz5USPgEFFaYr6Do",
-      "description": "Generated test vector #1081",
-      "expected": [
-        "coil",
-        "pardon",
-        "hire",
-        "tissue",
-        "glory"
-      ]
-    },
-    {
-      "address": "osmo1q3UTj2GAgnlOaAYMoePRE6R1ASMFU",
-      "description": "Generated test vector #1082",
-      "expected": [
-        "horse",
-        "soft",
-        "gem",
-        "quiet",
-        "muffin"
-      ]
-    },
-    {
-      "address": "zG6qWZHpvroCY0OkznvBFe5wZKzfRsAxP5dRXSDdchpakOZv0Ka5G0",
-      "description": "Generated test vector #1083",
-      "expected": [
-        "allure",
-        "blush",
-        "result",
-        "autumn",
-        "endear"
-      ]
-    },
-    {
-      "address": "cosmos1j87A3w3wnM1a5sQlt0cvYaPNZUSJ0qyTBnM8QmQMYwDCROh",
-      "description": "Generated test vector #1084",
-      "expected": [
-        "capable",
-        "letter",
-        "corn",
-        "assume",
-        "profit"
-      ]
-    },
-    {
-      "address": "5zytCtypwFhhdJzJLM8rKzjtmLk4fzSmEVBNeTnpTddDHAxQwr9cu",
-      "description": "Generated test vector #1085",
-      "expected": [
-        "mutual",
-        "person",
-        "blessing",
-        "express",
-        "joyous"
-      ]
-    },
-    {
-      "address": "cosmos10KTUKo2GZY4bSwSnJOTIwxV7W71RlcFLz8sZGM3smUWF94w5zpWN",
-      "description": "Generated test vector #1086",
-      "expected": [
-        "close",
-        "arrange",
-        "nautilus",
-        "rubber",
-        "phrase"
-      ]
-    },
-    {
-      "address": "18d26uPskk0de84CVu9lCcJKpaMfLo48Lbw",
-      "description": "Generated test vector #1087",
-      "expected": [
-        "oval",
-        "rare",
-        "churn",
-        "exquisite",
-        "faucet"
-      ]
-    },
-    {
-      "address": "osmo1XVJeElTlO5qcNNw6FeHvDDb0w",
-      "description": "Generated test vector #1088",
-      "expected": [
-        "panic",
-        "glue",
-        "salt",
-        "wealth",
-        "offer"
-      ]
-    },
-    {
-      "address": "cosmos1tulT0jC9ClHLZz4ydmhY9WMFe6DL",
-      "description": "Generated test vector #1089",
-      "expected": [
-        "burger",
-        "precious",
-        "travel",
-        "well",
-        "drop"
-      ]
-    },
-    {
-      "address": "1PxtQgefUsRPpzu2lzx5DjKdaralzUZF1s5l",
-      "description": "Generated test vector #1090",
-      "expected": [
-        "whisper",
-        "inspire",
-        "rejuvenate",
-        "broccoli",
-        "among"
-      ]
-    },
-    {
-      "address": "1w4ERCTmUf9ocd1ypkkyN8NS6YCM1XWnD9",
-      "description": "Generated test vector #1091",
-      "expected": [
-        "express",
-        "cycle",
-        "dignity",
-        "palm",
-        "salmon"
-      ]
-    },
-    {
-      "address": "U7RUV5BY51vXEZviRr72XMc5HRASKzMpST2Nfxug3aEM0QhjaAM",
-      "description": "Generated test vector #1092",
-      "expected": [
-        "client",
-        "oasis",
-        "hoping",
-        "stroll",
-        "prudence"
-      ]
-    },
-    {
-      "address": "nLzicMrNGVw0o3G3oylcoiYtEdPPhLwfdsw6ca",
-      "description": "Generated test vector #1093",
-      "expected": [
-        "fervent",
-        "exact",
-        "rocket",
-        "renaissance",
-        "truly"
-      ]
-    },
-    {
-      "address": "bc1qVz2GbVUeRl1OxdPNAhRiJ4D61K",
-      "description": "Generated test vector #1094",
-      "expected": [
-        "cave",
-        "barrel",
-        "reveal",
-        "glad",
-        "cable"
-      ]
-    },
-    {
-      "address": "3h7r5ZKVAqaeiK3wAvYuN65zPhk0a1Att6dPbXrMKGjP1D4LnvOkkIp3iQHaU",
-      "description": "Generated test vector #1095",
-      "expected": [
-        "enable",
-        "relief",
-        "vivacious",
-        "friend",
-        "simple"
-      ]
-    },
-    {
-      "address": "KzSrjYIoInkwyWsmLSAFMhpfVD4RWLwuBtWGwB",
-      "description": "Generated test vector #1096",
-      "expected": [
-        "habit",
-        "worth",
-        "ahead",
-        "blossom",
-        "geekier"
-      ]
-    },
-    {
-      "address": "1qrMSEkkTVmtzH3mLlxRgvCVygO5CxVOzD1xRRCKZwHYTG",
-      "description": "Generated test vector #1097",
-      "expected": [
-        "valid",
-        "duck",
-        "copper",
-        "key",
-        "cause"
-      ]
-    },
-    {
-      "address": "19JOp94aSHpsKpiW2ijT9U88YK1BixmFMfj2blnDNZQ1",
-      "description": "Generated test vector #1098",
-      "expected": [
-        "stellar",
-        "nurturing",
-        "aware",
-        "grape",
-        "axis"
-      ]
-    },
-    {
-      "address": "3scAHSED25NHyKEdBZs9g3bUM2g5Li2WSJVUpSiNbzF",
-      "description": "Generated test vector #1099",
-      "expected": [
-        "pizza",
-        "ripple",
-        "trophy",
-        "ledger",
-        "olive"
-      ]
-    },
-    {
-      "address": "bc1qZe0ToElX9juKMKt3Et9fHAZx4gyXlIIKpHJI7sR4hVQwGi4",
-      "description": "Generated test vector #1100",
-      "expected": [
-        "cupboard",
-        "anew",
-        "find",
-        "cost",
-        "spare"
-      ]
-    },
-    {
-      "address": "0xjnt92c7vcOWJQGbkzRcDktqEaKBOUOUeehjh5HSHGSfOy6LDUi2215GYr8yfJ",
-      "description": "Generated test vector #1101",
-      "expected": [
-        "hybrid",
-        "brick",
-        "lucky",
-        "blithe",
-        "six"
-      ]
-    },
-    {
-      "address": "cosmos1NAc2uVUS7vSi29WiqjHHgA4Yr2",
-      "description": "Generated test vector #1102",
-      "expected": [
-        "like",
-        "precious",
-        "suggest",
-        "raise",
-        "heaven"
-      ]
-    },
-    {
-      "address": "5KYwvxBfq50IpDwjbPxlsCHlNWGeMs0Cdr2Nldyc6TtCWCW6jeFzEZ",
-      "description": "Generated test vector #1103",
-      "expected": [
-        "another",
-        "rough",
-        "arrest",
-        "subject",
-        "blameless"
-      ]
-    },
-    {
-      "address": "IR2djZsFdxsmqwNB9SJsHJiuF0R4EwsZL0C2d7jOCLEMxph5QLt1bI4zdXgdX9y",
-      "description": "Generated test vector #1104",
-      "expected": [
-        "group",
-        "pretty",
-        "soccer",
-        "robust",
-        "scissors"
-      ]
-    },
-    {
-      "address": "1uzcqDgmDPbmF2EdldT66wOgH6J4dulLqnwP2mmLQnNfksXiFNmQnMoiE",
-      "description": "Generated test vector #1105",
-      "expected": [
-        "twelve",
-        "hardy",
-        "imitate",
-        "seat",
-        "beauty"
-      ]
-    },
-    {
-      "address": "5whPOhYoO08irQs5QC3Jq2rgnodRrsTaSEaTQxjF4dS4UgAsdVW",
-      "description": "Generated test vector #1106",
-      "expected": [
-        "frame",
-        "trade",
-        "endear",
-        "vivacious",
-        "feel"
-      ]
-    },
-    {
-      "address": "3ukushvmtNN1LgGGvkVaMSLMydEJpVnVagElmFb",
-      "description": "Generated test vector #1107",
-      "expected": [
-        "clutch",
-        "fertile",
-        "vast",
-        "blessing",
-        "pure"
-      ]
-    },
-    {
-      "address": "ZEa5mhKNTXofG7U1BAP308xdfyqvIfswDVpzILIsaX2",
-      "description": "Generated test vector #1108",
-      "expected": [
-        "unaffected",
-        "junior",
-        "spice",
-        "symbol",
-        "wow"
-      ]
-    },
-    {
-      "address": "bc1qcty8XTMtUlH33jwYxXTKEH0jCloMb",
-      "description": "Generated test vector #1109",
-      "expected": [
-        "talk",
-        "boat",
-        "preeminent",
-        "chunk",
-        "bicycle"
-      ]
-    },
-    {
-      "address": "5b9Koz0hlZsPUm8gDaPEmEDMGsqYq5cH0XSEGlRQpRejysuOpmFYa7vcI",
-      "description": "Generated test vector #1110",
-      "expected": [
-        "hilarious",
-        "inner",
-        "pair",
-        "rain",
-        "brand"
-      ]
-    },
-    {
-      "address": "cosmos15RHesbsnOkXVdSfaghbcstkHA7FScUgNyo",
-      "description": "Generated test vector #1111",
-      "expected": [
-        "peerless",
-        "edge",
-        "hawk",
-        "stem",
-        "that"
-      ]
-    },
-    {
-      "address": "osmo1gEilRwz0jEIQ051wEjwhfb9AsKD2AhkiYyBvZPB1SgQlxx2",
-      "description": "Generated test vector #1112",
-      "expected": [
-        "this",
-        "busy",
-        "befit",
-        "chime",
-        "lawn"
-      ]
-    },
-    {
-      "address": "5nW1OdtDEBpTAArrJyQ50OAbarmTov9gcPDWSMb4QVwbORNrwDUj",
-      "description": "Generated test vector #1113",
-      "expected": [
-        "snappy",
-        "aerobic",
-        "hail",
-        "ease",
-        "remain"
-      ]
-    },
-    {
-      "address": "osmo19yHHSIV2VTza8ZR5W25nbQgLyhZmXs4DXlwsI5uhlK9",
-      "description": "Generated test vector #1114",
-      "expected": [
-        "pray",
-        "authentic",
-        "voice",
-        "today",
-        "ocean"
-      ]
-    },
-    {
-      "address": "0EZSyEekE0XCohDozLHxKnh12oSHjKO8zeugH8aQb",
-      "description": "Generated test vector #1115",
-      "expected": [
-        "proud",
-        "volcano",
-        "tree",
-        "unbeatable",
-        "all"
-      ]
-    },
-    {
-      "address": "5Qflb11yZ12iIA0IWs1zcEEFKGx1GEsoZM6U3GvWjVIdJ",
-      "description": "Generated test vector #1116",
-      "expected": [
-        "beetle",
-        "return",
-        "drastic",
-        "renew",
-        "enrich"
-      ]
-    },
-    {
-      "address": "5AjRDGevq3u8TyNvu9KYuUqDtdbxNu",
-      "description": "Generated test vector #1117",
-      "expected": [
-        "primary",
-        "double",
-        "glow",
-        "topnotch",
-        "wash"
-      ]
-    },
-    {
-      "address": "5KpzIL5wc0tRprBpvsX2MnQ5hckblemJ7jdBFewCdxiCeiAIC8OJxaomG76a",
-      "description": "Generated test vector #1118",
-      "expected": [
-        "soothe",
-        "priceless",
-        "agile",
-        "shuffle",
-        "boring"
-      ]
-    },
-    {
-      "address": "qzkWmhFFMTPQ9j688IHw1lKLFgRbnWW1ZqesWRdmFYUlL",
-      "description": "Generated test vector #1119",
-      "expected": [
-        "orange",
-        "spoil",
-        "benefit",
-        "wisdom",
-        "amount"
-      ]
-    },
-    {
-      "address": "1F5kzMmVFor25xcjc4HitxQQelFxvyrcsF42GXKfCaV",
-      "description": "Generated test vector #1120",
-      "expected": [
-        "soft",
-        "master",
-        "album",
-        "wild",
-        "raven"
-      ]
-    },
-    {
-      "address": "5gwwGaONgGd88zeldmBLotB0YKYxqYSi3LtVYYqcNXpy24y3uXgocSOb",
-      "description": "Generated test vector #1121",
-      "expected": [
-        "brick",
-        "piety",
-        "learn",
-        "owl",
-        "perfect"
-      ]
-    },
-    {
-      "address": "bc1quRPecRH8cEWDhFgTJIFaGId4nHNgUn3o",
-      "description": "Generated test vector #1122",
-      "expected": [
-        "pray",
-        "sure",
-        "access",
-        "ambitious",
-        "slab"
-      ]
-    },
-    {
-      "address": "35EK3nu5N9dJRpWrwxFLsoTc2gpareCbgeVYKJTdp5x5AaYI1orRx01J",
-      "description": "Generated test vector #1123",
-      "expected": [
-        "scale",
-        "puppy",
-        "pumpkin",
-        "drift",
-        "altruistic"
-      ]
-    },
-    {
-      "address": "0xAosFgO1WfhT2ftHy3GoQ3a9MGt0oDczXKjFYTviD1HD5lqBKESYEu",
-      "description": "Generated test vector #1124",
-      "expected": [
-        "rely",
-        "maximum",
-        "ease",
-        "town",
-        "pizza"
-      ]
-    },
-    {
-      "address": "bc1qcmvQraO5lF5pU1As1ctDXJynQQ0cKDdhbF2OFGj",
-      "description": "Generated test vector #1125",
-      "expected": [
-        "shoulder",
-        "column",
-        "million",
-        "axis",
-        "haunting"
-      ]
-    },
-    {
-      "address": "puHn7VaLVOUMla2C2TKFv5wXR9j3GZsHYS5iuzKIFl7jgbLBfkRIQ456wuL0vrk",
-      "description": "Generated test vector #1126",
-      "expected": [
-        "extend",
-        "mutual",
-        "scan",
-        "ember",
-        "energy"
-      ]
-    },
-    {
-      "address": "xDkzJGbe49RzC5DInDEn8WXNDPf24jKfEMWpxlVjHycggjs9zrqOMz",
-      "description": "Generated test vector #1127",
-      "expected": [
-        "project",
-        "exquisite",
-        "backed",
-        "posh",
-        "hello"
-      ]
-    },
-    {
-      "address": "S8Uxyr9dFCBO6nXIsNddYkqMa0dUoPXM9SwwxnvSWNo66IHBh8amlxWA",
-      "description": "Generated test vector #1128",
-      "expected": [
-        "pleasant",
-        "approve",
-        "unusual",
-        "gospel",
-        "try"
-      ]
-    },
-    {
-      "address": "cosmos11O1uKvnaDz9iGslOftbytnR1K",
-      "description": "Generated test vector #1129",
-      "expected": [
-        "godsend",
-        "monitor",
-        "toss",
-        "caught",
-        "gate"
-      ]
-    },
-    {
-      "address": "qzkDymd6ZvGG6adbP5m8S1fvCwRTTnmDSJzciGQzR5gi9cORrTiKVNC6",
-      "description": "Generated test vector #1130",
-      "expected": [
-        "thumb",
-        "update",
-        "envelope",
-        "sing",
-        "resource"
-      ]
-    },
-    {
-      "address": "qzkJl8tKFMPNFXGtHOSHGKx3jBF6YP4RtpvUd0wDemO6N4kGeyqm",
-      "description": "Generated test vector #1131",
-      "expected": [
-        "thunder",
-        "jungle",
-        "flutter",
-        "air",
-        "helmet"
-      ]
-    },
-    {
-      "address": "38FIAhpMCgpEIUQpcRbi8javQqfpHUHeI",
-      "description": "Generated test vector #1132",
-      "expected": [
-        "stereo",
-        "position",
-        "already",
-        "modify",
-        "open"
-      ]
-    },
-    {
-      "address": "573ieF1EyH27y0FxbkAr25qhfopPBlZa5o",
-      "description": "Generated test vector #1133",
-      "expected": [
-        "chill",
-        "divide",
-        "science",
-        "puppy",
-        "setup"
-      ]
-    },
-    {
-      "address": "bc1q1C097CUKoRmGiyUCGk6PUXqIBS89t7L50uDxrrLbiPWhcKXJI9jO4i",
-      "description": "Generated test vector #1134",
-      "expected": [
-        "develop",
-        "beauty",
-        "painless",
-        "minute",
-        "congress"
-      ]
-    },
-    {
-      "address": "1MqJFyIfpD7MYEZXGeo5jV61vZJ2EVy0A",
-      "description": "Generated test vector #1135",
-      "expected": [
-        "alien",
-        "hobby",
-        "ancient",
-        "convince",
-        "topple"
-      ]
-    },
-    {
-      "address": "0xYztuf14h0LKkCc0DTjMxnXuwmjsb9TF2QqlUyK7oFqT7KUd",
-      "description": "Generated test vector #1136",
-      "expected": [
-        "tackle",
-        "overjoyed",
-        "easy",
-        "node",
-        "charge"
-      ]
-    },
-    {
-      "address": "osmo180jIAmglQdHOpramlMyJjTUhnApujQGAYEK0FgVnVB2Sh5SVAmaiGvS",
-      "description": "Generated test vector #1137",
-      "expected": [
-        "rapport",
-        "donor",
-        "basic",
-        "royal",
-        "sunny"
-      ]
-    },
-    {
-      "address": "1PO8JngNf4Y7PKJauD347Fz0LEyHVdlgfSnPhynfLnDyEJsNK5Yx4tqvhiVE",
-      "description": "Generated test vector #1138",
-      "expected": [
-        "update",
-        "bloom",
-        "alcohol",
-        "vibrant",
-        "buff"
-      ]
-    },
-    {
-      "address": "qzk5obIwPGprhjFDfsfiFCz3Wl5qSj7Gsh2xH",
-      "description": "Generated test vector #1139",
-      "expected": [
-        "nephew",
-        "goose",
-        "glee",
-        "employ",
-        "write"
-      ]
-    },
-    {
-      "address": "5Eq5CeNq4gXcYiSpTJpWFy0eOtdYqmKiZPPvLKl5nTCwlS61vw3vT5hiNWr",
-      "description": "Generated test vector #1140",
-      "expected": [
-        "glitter",
-        "estate",
-        "also",
-        "large",
-        "boring"
-      ]
-    },
-    {
-      "address": "5Lf5NcBi6OPM0AKg7cg1h0mtYbLhbwwbuVZmFy",
-      "description": "Generated test vector #1141",
-      "expected": [
-        "lyrics",
-        "side",
-        "across",
-        "aspiration",
-        "poise"
-      ]
-    },
-    {
-      "address": "1Dl4578KOdZ8vkL1B2reg52PWQcDesWUdSzCeIXjRH",
-      "description": "Generated test vector #1142",
-      "expected": [
-        "hold",
-        "free",
-        "label",
-        "enough",
-        "flourish"
-      ]
-    },
-    {
-      "address": "54A5veQR2VboDYDAwBoyrL5lAYLTHfse6UvLR",
-      "description": "Generated test vector #1143",
-      "expected": [
-        "author",
-        "spatial",
-        "permissible",
-        "salmon",
-        "jolly"
-      ]
-    },
-    {
-      "address": "3rxszDe56Es6MWsAsdwCkCktOzg4omZIl",
-      "description": "Generated test vector #1144",
-      "expected": [
-        "alarm",
-        "kangaroo",
-        "grand",
-        "music",
-        "human"
-      ]
-    },
-    {
-      "address": "qzkcScMk1xXpqz6wlv0gKytEfqV3drVNhaMaAhRInwAy",
-      "description": "Generated test vector #1145",
-      "expected": [
-        "jolly",
-        "cotton",
-        "scan",
-        "fox",
-        "hug"
-      ]
-    },
-    {
-      "address": "5Nf6HALNC3AaTcLZz9SnmTYx8klv7q6PO6xDaeNj7fQdvP8Y",
-      "description": "Generated test vector #1146",
-      "expected": [
-        "observe",
-        "noble",
-        "term",
-        "cable",
-        "engine"
-      ]
-    },
-    {
-      "address": "3ohHq3IcDN9dIyxG6eEm8sjh9F8httuCOQ85y",
-      "description": "Generated test vector #1147",
-      "expected": [
-        "poem",
-        "mercy",
-        "moral",
-        "befit",
-        "gain"
-      ]
-    },
-    {
-      "address": "0xltPeq6kFeCrsLyA4J8mOgmdRPJMykJK0mybryihJATFybHSZvhR5o",
-      "description": "Generated test vector #1148",
-      "expected": [
-        "alpha",
-        "banana",
+        "banner",
+        "foster",
+        "meadow",
         "table",
-        "quiet",
-        "access"
+        "rely"
       ]
     },
     {
-      "address": "osmo1CxxRVoYOhCrnmN9ITb3FgIRsi5KAvm0PQA",
-      "description": "Generated test vector #1149",
+      "address": "3aGVirHQEUsVXLXHl2BpSOZneMGXMRqOGqleigCCREtj8b8rh",
+      "description": "Generated test vector #95",
       "expected": [
-        "bonus",
-        "uncover",
-        "wins",
-        "unmatched",
-        "bliss"
+        "focus",
+        "wash",
+        "admire",
+        "ultra",
+        "sturdier"
       ]
     },
     {
-      "address": "5HDsFB6wkVruHUFYFOqI5fggcQCjJqPQ04VR",
-      "description": "Generated test vector #1150",
+      "address": "qzkojEvtX9CXu07dWeDl0YZhVpVBTc",
+      "description": "Generated test vector #96",
       "expected": [
-        "glitter",
-        "creek",
-        "tiny",
-        "vessel",
+        "key",
+        "upgrade",
+        "antenna",
+        "moon",
+        "acoustic"
+      ]
+    },
+    {
+      "address": "qzkG8DQtuNc6GpNm31nhNukrhWacWDKxfjfM",
+      "description": "Generated test vector #97",
+      "expected": [
+        "steel",
+        "help",
+        "glove",
+        "gold",
+        "mercy"
+      ]
+    },
+    {
+      "address": "0xwjHgEtINv3TbxSpcRIHEJHuD1L1jGBY",
+      "description": "Generated test vector #98",
+      "expected": [
+        "situate",
+        "iron",
+        "flight",
+        "supple",
+        "sugar"
+      ]
+    },
+    {
+      "address": "CWFT2MwMtd7YlQVjrztfOc6lbglbNyEMKdnSa5O5ZDNwU3YXdMGTZ",
+      "description": "Generated test vector #99",
+      "expected": [
+        "catch",
+        "barn",
+        "air",
+        "travel",
+        "salad"
+      ]
+    },
+    {
+      "address": "17gSGlGpMlUzgNwCP2klyuj9Bvt9uxVATLInV5p7ByT",
+      "description": "Generated test vector #100",
+      "expected": [
+        "forward",
+        "crowd",
+        "festival",
+        "lamp",
         "artefact"
       ]
     },
     {
-      "address": "bc1qIGn9USnnguQUrwUsoe56E395Xh0OHF14cQ3Us1HkQf",
-      "description": "Generated test vector #1151",
+      "address": "cosmos1G9ssn1bYQrII5jcwiwKoYfy4",
+      "description": "Generated test vector #101",
       "expected": [
-        "wealth",
-        "tonight",
-        "normal",
-        "frame",
-        "already"
+        "hotcake",
+        "dry",
+        "young",
+        "either",
+        "know"
       ]
     },
     {
-      "address": "osmo1j10EQPamJ6Pq2UBj2PwaOHcwwwkwy4RkbnwffaTNOkqKV5oT3TXh",
-      "description": "Generated test vector #1152",
+      "address": "1XkZQJ4KsTJedVvYz11oOLaWxscHjFndTyBKFnryifJdyfFVii",
+      "description": "Generated test vector #102",
       "expected": [
-        "aim",
-        "indoor",
-        "kitten",
-        "city",
-        "facilitate"
+        "valid",
+        "unusual",
+        "picnic",
+        "neat",
+        "crystal"
       ]
     },
     {
-      "address": "qzkQKC8MUNRSIVbSTKCL7ywdu6ERNwiraxSm",
-      "description": "Generated test vector #1153",
+      "address": "EOmMTpeWu5fPAvtKbs9M9BjcYmxU0gd651YaRgBbmH",
+      "description": "Generated test vector #103",
       "expected": [
-        "sweet",
-        "text",
-        "smart",
-        "alien",
-        "diplomat"
+        "today",
+        "round",
+        "device",
+        "snow",
+        "mature"
       ]
     },
     {
-      "address": "qzkVfWT5GimDm6bwRH3QYgQh9LtgI3JdY",
-      "description": "Generated test vector #1154",
+      "address": "bc1qGqDTiRbKPckrWMdOayq0O1b1Oox8gt1GlFC5bpGuyjvvMo8FYM23YbIrj3Of",
+      "description": "Generated test vector #104",
       "expected": [
-        "vintage",
-        "talk",
-        "develop",
-        "balloon",
-        "undeniable"
+        "fame",
+        "indicate",
+        "record",
+        "flight",
+        "brilliance"
       ]
     },
     {
-      "address": "qzkhNSaZYwLrAy14KTonVBujwdOk8gyLPeZFLe68",
-      "description": "Generated test vector #1155",
+      "address": "57LMooj84uHmiHX1tRGi98i54tI6ht2TV2zzB535qWglVLqJooQwQDFLSx0Eilb",
+      "description": "Generated test vector #105",
       "expected": [
-        "brain",
-        "vapor",
-        "again",
-        "secret",
-        "tattoo"
-      ]
-    },
-    {
-      "address": "3YfFqg3wU3nGdc8aYvo7CKxrFCMgXgf7fqafY3OuE6J3ANzg5LRia8CpTYJ",
-      "description": "Generated test vector #1156",
-      "expected": [
-        "program",
-        "brick",
-        "shell",
-        "initial",
-        "taste"
-      ]
-    },
-    {
-      "address": "0xlXDoga6mmTH2nQZ90I3AjOfM9a1GPCu8EY1NsxOxOce1YM8HwJRuPji",
-      "description": "Generated test vector #1157",
-      "expected": [
-        "captain",
-        "until",
-        "nut",
-        "advance",
-        "nut"
-      ]
-    },
-    {
-      "address": "osmo1ribvPgCP5fvhSstGEY4p0v3MGD4O",
-      "description": "Generated test vector #1158",
-      "expected": [
-        "belt",
-        "adjust",
-        "artefact",
-        "decide",
-        "gentle"
-      ]
-    },
-    {
-      "address": "5Nq7dMay6HGTx1LobYV4rymvlVCOy35ZaaMEuJhny",
-      "description": "Generated test vector #1159",
-      "expected": [
-        "churn",
-        "tone",
-        "salamander",
-        "sincere",
-        "available"
-      ]
-    },
-    {
-      "address": "hyikx9f7Tf6J7dBh9BQyJTTweK40FzeHKJBWVgYjtjRCqWo",
-      "description": "Generated test vector #1160",
-      "expected": [
-        "hold",
-        "quick",
-        "craft",
-        "core",
-        "frisky"
-      ]
-    },
-    {
-      "address": "0xXeOx8J5Yu9dwfqMC3LOw9nFi96r6lGlRYZl4KtB3NRfPXpI8c2ch0o",
-      "description": "Generated test vector #1161",
-      "expected": [
-        "legend",
-        "oblige",
-        "forget",
-        "blouse",
-        "gorilla"
-      ]
-    },
-    {
-      "address": "cosmos1EOA638ZxD0niA4sYtdlAxvpHmKMRxT57d60IJtayqCPz6DN2wQyQFP3i",
-      "description": "Generated test vector #1162",
-      "expected": [
-        "lens",
-        "unlimited",
-        "tool",
-        "aerobic",
-        "under"
-      ]
-    },
-    {
-      "address": "gksHAN0JcXCWjanEzWHaoxymH9qOANie7pIotFFEhPSkTM1",
-      "description": "Generated test vector #1163",
-      "expected": [
-        "behind",
-        "spend",
-        "icon",
-        "cook",
-        "vast"
-      ]
-    },
-    {
-      "address": "bc1qujSH2khHTsdbkJl7HXCbEkDbiEQHhf3dTZUNXeDluwF6qK3rguEej",
-      "description": "Generated test vector #1164",
-      "expected": [
-        "crouch",
-        "swap",
-        "ride",
-        "because",
-        "rise"
-      ]
-    },
-    {
-      "address": "0xjhaPxJkYoS23l4vhlczhgfb8nGGZ5kmBUmsfPei7ylt0dgbCere5p4wfgl",
-      "description": "Generated test vector #1165",
-      "expected": [
-        "cure",
-        "repeat",
-        "live",
-        "city",
-        "halcyon"
-      ]
-    },
-    {
-      "address": "le8AXrlJqIXBHSGAhshUvd0grsdAesWdevJeflakZNjkAm6FdNXsph08GpXv7S4",
-      "description": "Generated test vector #1166",
-      "expected": [
-        "drum",
-        "south",
-        "pair",
-        "twelve",
-        "view"
-      ]
-    },
-    {
-      "address": "3JlazGOhh8s17igJgYPwg5rRBEg4paCHIjDacWW8R",
-      "description": "Generated test vector #1167",
-      "expected": [
-        "grand",
-        "topic",
-        "terrific",
-        "soothe",
-        "merkle"
-      ]
-    },
-    {
-      "address": "3YiKkLf2IQIz0uKmgBdFlrDN7rhHprcxAP6",
-      "description": "Generated test vector #1168",
-      "expected": [
-        "arrive",
-        "speak",
-        "keen",
-        "topic",
-        "lyrics"
-      ]
-    },
-    {
-      "address": "1XxkCivQFZ3YLWb5BHl12psBto393PmMfq4xyAnrNGooiz1Zyah81gdSw1m80B",
-      "description": "Generated test vector #1169",
-      "expected": [
-        "crunch",
-        "always",
-        "big",
-        "uncover",
-        "scene"
-      ]
-    },
-    {
-      "address": "0xj0M9PWki3g9AHJY5XKpm3jllaaQoG6uq",
-      "description": "Generated test vector #1170",
-      "expected": [
-        "wealth",
-        "mirth",
-        "miracle",
-        "render",
-        "judicious"
-      ]
-    },
-    {
-      "address": "1gmji1ssX4kzmay10j3VNMpJ9maljL5lWkBoi0k0NE6b2CxtESjDdigvP9Hc",
-      "description": "Generated test vector #1171",
-      "expected": [
-        "reunion",
-        "castle",
-        "clap",
         "cool",
-        "region"
+        "cheese",
+        "tongue",
+        "letter",
+        "irreplaceable"
+      ]
+    },
+    {
+      "address": "0x6nPmmk7BMQ13AWLZSy6JHNRcgC22pH8cyV7lB2Vrks4Q4",
+      "description": "Generated test vector #106",
+      "expected": [
+        "hotel",
+        "admit",
+        "undefeated",
+        "buzz",
+        "exalt"
+      ]
+    },
+    {
+      "address": "qzkfFlK3HyubC332fuOSkTfRNfRT8LjIcku21kiVdtT7rl37aVaEEYLEnO",
+      "description": "Generated test vector #107",
+      "expected": [
+        "fame",
+        "detail",
+        "welcome",
+        "lizard",
+        "camp"
+      ]
+    },
+    {
+      "address": "qzkBLa2rMYmldvjcJLufg9krORJI7UwcVu3YV0eDh1uznmdJ8GfSLWRA",
+      "description": "Generated test vector #108",
+      "expected": [
+        "bloom",
+        "heaven",
+        "fiery",
+        "dish",
+        "youth"
+      ]
+    },
+    {
+      "address": "osmo1G9viIGNElLR8abMh0X9zuINamrWtFuaQvSMbkuuP4",
+      "description": "Generated test vector #109",
+      "expected": [
+        "gusto",
+        "ember",
+        "equal",
+        "have",
+        "suggest"
+      ]
+    },
+    {
+      "address": "0xDM3HuWzUZsStHmQX3v8rb8M0JyK1URtbzEoC",
+      "description": "Generated test vector #110",
+      "expected": [
+        "empower",
+        "fortune",
+        "cook",
+        "duty",
+        "stellar"
+      ]
+    },
+    {
+      "address": "cosmos1GkxcmfFX4jvD2tuVg8G9mcy1htc02u3gVUbV",
+      "description": "Generated test vector #111",
+      "expected": [
+        "march",
+        "surprise",
+        "fantasy",
+        "basic",
+        "confirm"
+      ]
+    },
+    {
+      "address": "bc1qmrHVPqjh7IgHIq6XJkt3Hdb4dxfyR3NQBwumVYe5VJfXRg",
+      "description": "Generated test vector #112",
+      "expected": [
+        "intricate",
+        "bridge",
+        "multiply",
+        "physical",
+        "crowd"
+      ]
+    },
+    {
+      "address": "cosmos1D6i3pwl4u1uEegD0rvJFzSgIesCKopjDemRA8JvRkPTSZhKugBtz",
+      "description": "Generated test vector #113",
+      "expected": [
+        "swallow",
+        "encourage",
+        "cereal",
+        "majestic",
+        "general"
+      ]
+    },
+    {
+      "address": "1uNdniKUYUOCsMBm2sXQ46S49KLF00d38aI8grbAKMSzAnkiI0wzr2",
+      "description": "Generated test vector #114",
+      "expected": [
+        "venerate",
+        "floor",
+        "rapture",
+        "grass",
+        "math"
+      ]
+    },
+    {
+      "address": "3aOi2O8iiX13R5MCAYxnAaETSq5JccDwJ7eTG1",
+      "description": "Generated test vector #115",
+      "expected": [
+        "exonerate",
+        "meticulous",
+        "rapture",
+        "prowess",
+        "exit"
+      ]
+    },
+    {
+      "address": "cosmos1GGLpNPPQHJM4HaC4Juv8skRLsWqNJJOsTbEheWpMrpTL4TOwkWol",
+      "description": "Generated test vector #116",
+      "expected": [
+        "quantum",
+        "possible",
+        "grid",
+        "click",
+        "attitude"
+      ]
+    },
+    {
+      "address": "vfi5jE9VoBNnTvNUhkysUUHxRDi1a5BQ",
+      "description": "Generated test vector #117",
+      "expected": [
+        "milk",
+        "cushion",
+        "ally",
+        "renaissance",
+        "face"
+      ]
+    },
+    {
+      "address": "gGv0LOqqXpKCPoPVGQ9taaezGQvSpcMd",
+      "description": "Generated test vector #118",
+      "expected": [
+        "turkey",
+        "before",
+        "differ",
+        "artefact",
+        "attune"
+      ]
+    },
+    {
+      "address": "bc1qRh1iO3J73RpC6N5rA4VukeWxud7qBE5Ll",
+      "description": "Generated test vector #119",
+      "expected": [
+        "kidney",
+        "royal",
+        "hooray",
+        "coin",
+        "dream"
+      ]
+    },
+    {
+      "address": "qzkiVnN4SgeJpB3jN5PqR4JF6EB0WWHa7YDJ",
+      "description": "Generated test vector #120",
+      "expected": [
+        "noiseless",
+        "all",
+        "rapid",
+        "gold",
+        "sing"
+      ]
+    },
+    {
+      "address": "osmo1QyN7fH7eCVOkcxlR3NwfNTilSKEdHtHZB9cdWchYPCQ2jJ",
+      "description": "Generated test vector #121",
+      "expected": [
+        "broccoli",
+        "forget",
+        "silver",
+        "today",
+        "century"
+      ]
+    },
+    {
+      "address": "1TEb4MpOaN4YgLZdYhKMdmuZTyhQHt7n",
+      "description": "Generated test vector #122",
+      "expected": [
+        "face",
+        "quarter",
+        "outside",
+        "skate",
+        "estate"
+      ]
+    },
+    {
+      "address": "0xuhizRIB5cg0LWaEalfO2zYVQmNGz6LclE6MWvao",
+      "description": "Generated test vector #123",
+      "expected": [
+        "ostrich",
+        "dog",
+        "merkle",
+        "worth",
+        "yellow"
+      ]
+    },
+    {
+      "address": "18M19FCMmdgj04Ej5dwmpM3CgdHjbFeoBJzU3ogoozm3eKdBnLlxCmwqubJrgCz",
+      "description": "Generated test vector #124",
+      "expected": [
+        "evocative",
+        "message",
+        "ten",
+        "below",
+        "swank"
+      ]
+    },
+    {
+      "address": "osmo12LWNLk81f1E9KZrTTpuJ3KjJa8cDVcGDXYCoIaT",
+      "description": "Generated test vector #125",
+      "expected": [
+        "lizard",
+        "fabric",
+        "special",
+        "december",
+        "hat"
+      ]
+    },
+    {
+      "address": "bc1qwo9aPkCJK8CiRl2MRaMxQGsURLJmQMu5F4",
+      "description": "Generated test vector #126",
+      "expected": [
+        "sun",
+        "salon",
+        "expire",
+        "stove",
+        "clarify"
+      ]
+    },
+    {
+      "address": "osmo1gwMwkIeRm8ohD6J7nUnvqQrdvEGh",
+      "description": "Generated test vector #127",
+      "expected": [
+        "levity",
+        "choose",
+        "mint",
+        "space",
+        "audit"
+      ]
+    },
+    {
+      "address": "3CwPQ82l2fyl7ekgjjm7bzQ5DATblbXZGuJOWEPGICJ3tWoxr0jr7MjHlkR4Xjh9",
+      "description": "Generated test vector #128",
+      "expected": [
+        "earth",
+        "cluster",
+        "lucrative",
+        "family",
+        "exonerate"
       ]
     }
   ]


### PR DESCRIPTION

## Summary

This PR upgrades the checkphrase construction from PBKDF2-HMAC-SHA256 to a
memory-hard KDF and fixes several structural weaknesses, across all four
implementations (Rust, JavaScript, Dart, Python reference).

**This is a breaking change: every checkphrase changes.** The scheme is
versioned as `human-checkphrase-v2` via the salt.

### Argon2id replaces PBKDF2 (the security fix)

PBKDF2 iterations impose only compute cost, and SHA-256 is the most
hardware-accelerated function in existence: a consumer GPU computes
~250,000 PBKDF2-40k guesses/second (~3,500x faster than the ~14 ms a wallet
pays per phrase), and mining ASICs widen the gap by several more orders of
magnitude. The old README's "GPU = 10x CPU" estimate significantly understated
this.

Argon2id (RFC 9106) with **64 MiB memory, 3 passes, parallelism 1** bounds
attacker throughput by memory bandwidth instead of core count, collapsing the
attacker/defender gap to roughly two orders of magnitude. Defender cost stays
UI-friendly at ~50–150 ms per phrase. Parallelism is fixed at 1 because
Argon2's output depends on it; this keeps all ports byte-identical.

- Rust: RustCrypto `argon2` crate
- JavaScript: `hash-wasm` (browser-compatible; **`addressToChecksum` is now
  `async`**)
- Dart: pointycastle `Argon2BytesGenerator`
- Python: `argon2-cffi` (new shared reference module `scripts/checkphrase.py`)

### Address normalization

Addresses are canonicalized before hashing: surrounding whitespace is
stripped, and `0x`-prefixed hex addresses are lowercased so EIP-55 checksum
casing cannot produce two different phrases for the same Ethereum address.
Base58/bech32/SS58 are case-sensitive and pass through unchanged; callers
must supply canonical forms (e.g. lowercase bech32). A test vector pins the
fact that lowercased base58 is deliberately a *different* address.

### Versioned, domain-separable salt

The salt is now the scheme version string `human-checkphrase-v2`, optionally
extended with a caller-supplied context: `human-checkphrase-v2|<context>`
(e.g. `eip155:1`). The version enables clean future migrations; the context
lets deployments domain-separate phrases per chain. Context is optional so
uncoordinated wallets still agree by default.

### Configurable word count

Word count is now a parameter (3–11, default 5). Five words (55 bits) remain
appropriate for verification; 8+ words are recommended if phrases are ever
used as lookup identifiers, where multi-target collision attacks apply. The
floor comes from Argon2's 4-byte minimum output, the ceiling from the u128
bit-slicing in the Rust port.

- Rust: `address_to_checksum_with_options(address, word_list, word_count, context)`
  (existing `address_to_checksum` keeps its signature and defaults)
- JS: `addressToChecksum(address, wordList, { wordCount, context })`
- Dart: `addressToChecksum(address, wordCount: ..., context: ...)`

## Other changes

- **Test vectors regenerated** (`test-vectors/checksums.json`): 149 cases
  including normalization variants, word counts 3/4/6/8/11, and context
  vectors. The suite shrank from 1171 cases because full 2048-word coverage
  at ~100 ms+ per Argon2 hash would make test runs (especially pure-Dart,
  ~500 ms/hash) take 10+ minutes; wordlist consistency across packages is
  already enforced by `scripts/sync_wordlists.py --check` in `run_tests.sh`.
  Vectors may carry optional `wordCount`/`context` fields; implementations
  default to 5 words / no context when absent.
- **README rewritten**: new example phrases, a precise spec of the v2 scheme,
  and an honest security analysis (verification vs. lookup threat models,
  multi-target attack costs, realistic GPU throughput numbers).
- **Rust cleanup**: dropped now-unused `hex`, `hmac`, `pbkdf2`, and `reqwest`
  dependencies (`reqwest` was unused before this PR too); bench now compares
  Argon2id against bare SHA-256.
- `scripts/words.py` demo now delegates to the shared reference
  implementation instead of duplicating the (old) scheme.
- `.gitignore`: added `.venv` and `__pycache__`.

## Test plan

- [x] `./run_tests.sh` passes: wordlist sync check, Rust (7 tests), JavaScript
      (14 tests), Dart (7 tests), all validating the same 149 shared vectors
- [x] Cross-implementation parity: identical phrases from Rust, JS, Dart, and
      Python for all vectors, including normalization/word-count/context cases
- [x] Normalization: EIP-55, `0X`-uppercase, and whitespace variants of the
      same Ethereum address produce identical phrases; lowercased base58
      produces a different phrase
- [x] Invalid word counts (<3, >11) rejected in all implementations
- [ ] Review Argon2 parameters (64 MiB) for acceptability on low-end mobile
      targets; drop to 32 MiB if needed (breaking, so decide before release)
- [ ] Bump package versions and coordinate the v1 -> v2 migration for any
      existing consumers (all phrases change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is a breaking cryptographic migration: all phrases change, JS consumers must adopt async `addressToChecksum`, and wallet integrators must align on v2 parameters, normalization, and optional context or users will see mismatched phrases.
> 
> **Overview**
> **Breaking:** every checkphrase changes. The scheme is versioned as `human-checkphrase-v2` (salt) and replaces PBKDF2-HMAC-SHA256 with **Argon2id** (64 MiB, t=3, p=1) across Rust, JavaScript, Dart, and a new Python reference (`scripts/checkphrase.py`).
> 
> Before hashing, addresses are **normalized** (trim; lowercase `0x` hex for EIP-55 consistency). Phrases can use **3–11 words** (default 5) and optional **domain context** (`human-checkphrase-v2|<context>`), exposed via `address_to_checksum_with_options` / JS `ChecksumOptions` / Dart named params. **JavaScript `addressToChecksum` is now async** (`hash-wasm`).
> 
> Shared **test vectors** are regenerated for v2 (smaller suite due to Argon2 cost) with normalization, word-count, and context cases. Docs and benches are updated; Rust drops PBKDF2/`reqwest` and related deps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a51238514097f14ef83b61435eb5bd708568911. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->